### PR TITLE
Support for installations behind Cloudflare and nginx>apache proxy

### DIFF
--- a/includes/database_mysql.php
+++ b/includes/database_mysql.php
@@ -2406,18 +2406,16 @@ class OGPDatabaseMySQL extends OGPDatabase
 	
 	public function logger($message){
 		$user_id = isset($_SESSION['user_id']) ? $_SESSION['user_id'] : 0;
-		if ( isset($_SERVER["REMOTE_ADDR"]) )
-		{
-			$client_ip = $_SERVER["REMOTE_ADDR"];
+		if(isset($_SERVER['HTTP_CF_CONNECTING_IP']) === true){
+			$client_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
+		}elseif(isset($_SERVER['HTTP_X_FORWARDED_FOR']) === true){
+			$client_ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+		}elseif(isset($_SERVER['HTTP_X_REAL_IP']) === true){
+			$client_ip = $_SERVER['HTTP_X_REAL_IP'];
+		}else{
+			$client_ip = $_SERVER['REMOTE_ADDR'];
 		}
-		elseif ( isset($_SERVER["HTTP_X_FORWARDED_FOR"]) )
-		{
-			$client_ip = $_SERVER["HTTP_X_FORWARDED_FOR"];
-		} 
-		elseif( isset($_SERVER["HTTP_CLIENT_IP"]) )
-		{
-			$client_ip = $_SERVER["HTTP_CLIENT_IP"]; 
-		}
+		
 		$message = mysql_real_escape_string($message, $this->link);
 		$this->query("INSERT INTO OGP_DB_PREFIXlogger (date, user_id, ip, message) VALUE (FROM_UNIXTIME(UNIX_TIMESTAMP(), '%d-%m-%Y %H:%i:%s'), $user_id, '$client_ip', '$message');");
 	}

--- a/includes/database_mysqli.php
+++ b/includes/database_mysqli.php
@@ -2413,18 +2413,16 @@ class OGPDatabaseMySQL extends OGPDatabase
 	
 	public function logger($message){
 		$user_id = isset($_SESSION['user_id']) ? $_SESSION['user_id'] : 0;
-		if ( isset($_SERVER["REMOTE_ADDR"]) )
-		{
-			$client_ip = $_SERVER["REMOTE_ADDR"];
+		if(isset($_SERVER['HTTP_CF_CONNECTING_IP']) === true){
+			$client_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
+		}elseif(isset($_SERVER['HTTP_X_FORWARDED_FOR']) === true){
+			$client_ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+		}elseif(isset($_SERVER['HTTP_X_REAL_IP']) === true){
+			$client_ip = $_SERVER['HTTP_X_REAL_IP'];
+		}else{
+			$client_ip = $_SERVER['REMOTE_ADDR'];
 		}
-		elseif ( isset($_SERVER["HTTP_X_FORWARDED_FOR"]) )
-		{
-			$client_ip = $_SERVER["HTTP_X_FORWARDED_FOR"];
-		} 
-		elseif( isset($_SERVER["HTTP_CLIENT_IP"]) )
-		{
-			$client_ip = $_SERVER["HTTP_CLIENT_IP"]; 
-		}
+		
 		$message = mysqli_real_escape_string($this->link,$message);
 		$this->query("INSERT INTO OGP_DB_PREFIXlogger (date, user_id, ip, message) VALUE (FROM_UNIXTIME(UNIX_TIMESTAMP(), '%d-%m-%Y %H:%i:%s'), $user_id, '$client_ip', '$message');");
 	}

--- a/index.php
+++ b/index.php
@@ -208,18 +208,15 @@ function ogpHome()
 		}
 		
 		if ( isset($_POST['login']) )
-		{
-			if ( isset($_SERVER["REMOTE_ADDR"]) )
-			{
-				$client_ip = $_SERVER["REMOTE_ADDR"];
-			}
-			elseif ( isset($_SERVER["HTTP_X_FORWARDED_FOR"]) )
-			{
-				$client_ip = $_SERVER["HTTP_X_FORWARDED_FOR"];
-			} 
-			elseif( isset($_SERVER["HTTP_CLIENT_IP"]) )
-			{
-				$client_ip = $_SERVER["HTTP_CLIENT_IP"]; 
+		{	
+			if(isset($_SERVER['HTTP_CF_CONNECTING_IP']) === true){
+				$client_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
+			}elseif(isset($_SERVER['HTTP_X_FORWARDED_FOR']) === true){
+				$client_ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+			}elseif(isset($_SERVER['HTTP_X_REAL_IP']) === true){
+				$client_ip = $_SERVER['HTTP_X_REAL_IP'];
+			}else{
+				$client_ip = $_SERVER['REMOTE_ADDR'];
 			}
 			
 			$ban_list = $db->resultQuery("SHOW TABLES LIKE 'OGP_DB_PREFIXban_list';");
@@ -268,8 +265,18 @@ function ogpHome()
 		
 					require_once('includes/classes/recaptcha/autoload.php');
 					$recaptcha = new \ReCaptcha\ReCaptcha($secretkey);
-					$resp = $recaptcha->verify($gRecaptchaResponse, $_SERVER["REMOTE_ADDR"]);
-
+					
+					if(isset($_SERVER['HTTP_CF_CONNECTING_IP']) === true){
+						$userAddr = $_SERVER['HTTP_CF_CONNECTING_IP'];
+					}elseif(isset($_SERVER['HTTP_X_FORWARDED_FOR']) === true){
+						$userAddr = $_SERVER['HTTP_X_FORWARDED_FOR'];
+					}elseif(isset($_SERVER['HTTP_X_REAL_IP']) === true){
+						$userAddr = $_SERVER['HTTP_X_REAL_IP'];
+					}else{
+						$userAddr = $_SERVER['REMOTE_ADDR'];
+					}
+					
+					$resp = $recaptcha->verify($gRecaptchaResponse, $userAddr);
 					if (empty($gRecaptchaResponse) || !$resp->isSuccess()){
 						print_failure("Recaptcha failed. Try again!");
 						$view->refresh("index.php",5);

--- a/index.php
+++ b/index.php
@@ -276,7 +276,7 @@ function ogpHome()
 						$client_ip = $_SERVER['REMOTE_ADDR'];
 					}
 					
-					$resp = $recaptcha->verify($gRecaptchaResponse, $userAddr);
+					$resp = $recaptcha->verify($gRecaptchaResponse, $client_ip);
 					if (empty($gRecaptchaResponse) || !$resp->isSuccess()){
 						print_failure("Recaptcha failed. Try again!");
 						$view->refresh("index.php",5);

--- a/index.php
+++ b/index.php
@@ -267,13 +267,13 @@ function ogpHome()
 					$recaptcha = new \ReCaptcha\ReCaptcha($secretkey);
 					
 					if(isset($_SERVER['HTTP_CF_CONNECTING_IP']) === true){
-						$userAddr = $_SERVER['HTTP_CF_CONNECTING_IP'];
+						$client_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
 					}elseif(isset($_SERVER['HTTP_X_FORWARDED_FOR']) === true){
-						$userAddr = $_SERVER['HTTP_X_FORWARDED_FOR'];
+						$client_ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
 					}elseif(isset($_SERVER['HTTP_X_REAL_IP']) === true){
-						$userAddr = $_SERVER['HTTP_X_REAL_IP'];
+						$client_ip = $_SERVER['HTTP_X_REAL_IP'];
 					}else{
-						$userAddr = $_SERVER['REMOTE_ADDR'];
+						$client_ip = $_SERVER['REMOTE_ADDR'];
 					}
 					
 					$resp = $recaptcha->verify($gRecaptchaResponse, $userAddr);

--- a/js/modules/dashboard.js
+++ b/js/modules/dashboard.js
@@ -62,7 +62,7 @@ function updateWidgetData(){
 	//Pass sortorder variable to server using ajax to save state  
 	$.post('home.php?m=dashboard&p=updateWidgets', 'data='+$.toJSON(sortorder), function(response){ 
 		if(response.indexOf("success") < 0){
-			$("#console").html('<h0><div class="Failed">Failed to save you\'r operation! Please contact OGP...</div></h0>').hide().fadeIn(1000);  
+			$("#console").html('<h0><div class="Failed">Failed to update your widget order! Please contact your OGP admin in the meantime.</div></h0>').hide().fadeIn(1000);  
 		}
 	});  
 }

--- a/js/modules/user_games.js
+++ b/js/modules/user_games.js
@@ -187,7 +187,7 @@ $(document).ready(function() {
 				var selected = new Date(e.localDate);
 				if( selected <= now )
 				{
-					alert('The given expiration date has already expired.');
+					alert('The selected date has already passed.');
 					datePickerInput.value = "";
 				}
 			}
@@ -210,7 +210,7 @@ $(document).ready(function() {
 					selected  = new Date(date[2], date[1]-1, date[0], time[0], time[1], time[2], 0);
 				if( selected <= now )
 				{
-					alert('The given expiration date has already expired.');
+					alert('The selected date has already passed.');
 					this.value = "";
 				}
 			}

--- a/modules/ftp/includes/registerglobals.inc.php
+++ b/modules/ftp/includes/registerglobals.inc.php
@@ -103,7 +103,18 @@ else                                                     { $_SESSION["net2ftp_se
 if (isset($_SESSION["net2ftp_remote_addr_new"]) == true) { $_SESSION["net2ftp_remote_addr_old"] = $_SESSION["net2ftp_remote_addr_new"]; }
 else                                                     { $_SESSION["net2ftp_remote_addr_old"] = ""; }
 $_SESSION["net2ftp_session_id_new"]  = session_id();
-$_SESSION["net2ftp_remote_addr_new"] = $_SERVER["REMOTE_ADDR"];
+
+if(isset($_SERVER['HTTP_CF_CONNECTING_IP']) === true){
+	$client_ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
+}elseif(isset($_SERVER['HTTP_X_FORWARDED_FOR']) === true){
+	$client_ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+}elseif(isset($_SERVER['HTTP_X_REAL_IP']) === true){
+	$client_ip = $_SERVER['HTTP_X_REAL_IP'];
+}else{
+	$client_ip = $_SERVER['REMOTE_ADDR'];
+}
+
+$_SESSION["net2ftp_remote_addr_new"] = $client_ip;
 
 // -------------------------------------------------------------------------
 // 3 SERVER variabes
@@ -114,7 +125,7 @@ else                                            { $net2ftp_globals["PHP_SELF"]  
 if (isset($_SERVER["HTTP_REFERER"]) == true)    { $net2ftp_globals["HTTP_REFERER"]    = validateGenericInput($_SERVER["HTTP_REFERER"]); }
 else                                            { $net2ftp_globals["HTTP_REFERER"]    = ""; }
 if (isset($_SERVER["HTTP_USER_AGENT"]) == true) { $net2ftp_globals["HTTP_USER_AGENT"] = validateGenericInput($_SERVER["HTTP_USER_AGENT"]); }
-if (isset($_SERVER["REMOTE_ADDR"]) == true)     { $net2ftp_globals["REMOTE_ADDR"]     = validateGenericInput($_SERVER["REMOTE_ADDR"]); }
+if (isset($client_ip) === true)					{ $net2ftp_globals["REMOTE_ADDR"]     = validateGenericInput($client_ip); }
 if (isset($_SERVER["REMOTE_PORT"]) == true)     { $net2ftp_globals["REMOTE_PORT"]     = validateGenericInput($_SERVER["REMOTE_PORT"]); }
 
 // Action URL

--- a/modules/gamemanager/home_handling_functions.php
+++ b/modules/gamemanager/home_handling_functions.php
@@ -30,7 +30,7 @@ function get_query_port($server_xml, $server_port)
 	return $server_port;
 }
 
-function get_sart_cmd($remote,$server_xml,$home_info,$mod_id,$ip,$port)
+function get_start_cmd($remote,$server_xml,$home_info,$mod_id,$ip,$port)
 {	
 	$last_param = json_decode($home_info['last_param'], True);
 	
@@ -262,7 +262,7 @@ function exec_operation( $action, $home_id, $mod_id, $ip, $port )
 	}
 	elseif ( $action == "restart" AND $screen_running )
 	{
-		$start_cmd = get_sart_cmd($remote,$server_xml,$home_info,$mod_id,$ip,$port);
+		$start_cmd = get_start_cmd($remote,$server_xml,$home_info,$mod_id,$ip,$port);
 		// Do text replacements in cfg file
 		if( $server_xml->replace_texts )
 		{
@@ -293,7 +293,7 @@ function exec_operation( $action, $home_id, $mod_id, $ip, $port )
 	}
 	elseif ( $action == "start" AND ! $screen_running )
 	{
-		$start_cmd = get_sart_cmd($remote,$server_xml,$home_info,$mod_id,$ip,$port);
+		$start_cmd = get_start_cmd($remote,$server_xml,$home_info,$mod_id,$ip,$port);
 		// Do text replacements in cfg file
 		if( $server_xml->replace_texts )
 		{

--- a/modules/gamemanager/view_server_log.php
+++ b/modules/gamemanager/view_server_log.php
@@ -85,7 +85,7 @@ function exec_ogp_module()
 		// Using the refreshed class
 		if( isset($_GET['refreshed']) )
 		{
-			echo "<pre class='log'><xmp>".htmlentities($home_log)."</xmp></pre>";
+			echo "<pre class='log'>".htmlentities($home_log)."</pre>";
 		}
 		else
 		{
@@ -152,7 +152,7 @@ function exec_ogp_module()
 			}
 			else
 			{
-				echo "<pre class='log'><xmp>".$home_log."</xmp></pre>";
+				echo "<pre class='log'>".htmlentities($home_log)."</pre>";
 				print_failure( server_not_running );
 			}
 			echo create_back_button( $_GET['m'], 'game_monitor&home_id-mod_id-ip-port='.$_GET['home_id-mod_id-ip-port'] );


### PR DESCRIPTION
REMOTE_ADDR is always going to be set, therefore the current check is
pointless when trying to support the other variables. Additionally,
users running an installation behind Cloudflare will only get the
Cloudflare server IP that the remote user is being proxied by. And users
such as myself who run an nginx -> apache2 proxy (apache2 serving the
dynamic content) will be getting the local IP address logged. This
change is more important for the logger() functionality and fixes the aforementioned issue.