### PR TITLE
Minor Validation Added.

### DIFF
--- a/includes/database_mysql.php
+++ b/includes/database_mysql.php
@@ -506,14 +506,16 @@ class OGPDatabaseMySQL extends OGPDatabase
 			mysql_real_escape_string($parent_id,$this->link));
 		$results = $this->listQuery($query);
 		
-		foreach($results as $result){
-			$ids[] = $result['user_id'];
+		if($results !== false){
+			foreach($results as $result){
+				$ids[] = $result['user_id'];
+			}
+			
+			if(is_array($ids) && count($ids) > 0){
+				return $ids;
+			}
 		}
 		
-		if(is_array($ids) && count($ids) > 0){
-			return $ids;
-		}
-				
 		return false;
 	}
 	

--- a/includes/database_mysqli.php
+++ b/includes/database_mysqli.php
@@ -503,14 +503,16 @@ class OGPDatabaseMySQL extends OGPDatabase
 			mysqli_real_escape_string($this->link, $parent_id));
 		$results = $this->listQuery($query);
 		
-		foreach($results as $result){
-			$ids[] = $result['user_id'];
+		if($results !== false){
+			foreach($results as $result){
+				$ids[] = $result['user_id'];
+			}
+			
+			if(is_array($ids) && count($ids) > 0){
+				return $ids;
+			}
 		}
 		
-		if(is_array($ids) && count($ids) > 0){
-			return $ids;
-		}
-				
 		return false;
 	}
 	

--- a/lang/Danish/modules/gamemanager.php
+++ b/lang/Danish/modules/gamemanager.php
@@ -185,4 +185,5 @@ define('directory', "Mappe Sti");
 define('view_player_commands', "View Player Commands");
 define('hide_player_commands', "Hide Player Commands");
 define('no_online_players', "There are no online players.");
+define('invalid_game_mod_id', "Invalid game/mod id specified.");
 ?>

--- a/lang/Danish/modules/user_admin.php
+++ b/lang/Danish/modules/user_admin.php
@@ -102,4 +102,8 @@ define('group_with_id_does_not_exist', "Bruger med ID %s eksistere ikke.");
 define('are_you_sure_you_want_to_delete_group', "Er du sikker på, at du ville slette gruppen <em>%s</em>?");
 define('unable_to_delete_group', "Ikke muligt, at slette bruger %s.");
 define('successfully_deleted_group', "Slettet gruppen succesfuldt <b>%s</b>.");
+define('editing_profile', "Editing Profile: %s");
+define('valid_user', "Please specify a valid user.");
+define('enter_valid_username', "Please enter a valid username.");
+define('unexpected_role', "Unexpected user role received.");
 ?>

--- a/lang/Danish/modules/user_games.php
+++ b/lang/Danish/modules/user_games.php
@@ -210,4 +210,5 @@ define('level_up', "Level up");
 define('level_up_info', "Back to the previous folder.");
 define('add_folder', "Add folder");
 define('add_folder_info', "Write the name for the new folder, then click on the icon.");
+define('valid_user', "Please specify a valid user.");
 ?>

--- a/lang/English/modules/gamemanager.php
+++ b/lang/English/modules/gamemanager.php
@@ -185,4 +185,5 @@ define('directory', "Directory");
 define('view_player_commands', "View Player Commands");
 define('hide_player_commands', "Hide Player Commands");
 define('no_online_players', "There are no online players.");
+define('invalid_game_mod_id', "Invalid game/mod id specified.");
 ?>

--- a/lang/English/modules/user_admin.php
+++ b/lang/English/modules/user_admin.php
@@ -102,4 +102,8 @@ define('group_with_id_does_not_exist', "%s group does not exist.");
 define('are_you_sure_you_want_to_delete_group', "Are you sure you want to delete group <em>%s</em>?");
 define('unable_to_delete_group', "Unable to delete %s group.");
 define('successfully_deleted_group', "Successfully deleted group <b>%s</b>.");
+define('editing_profile', "Editing Profile: %s");
+define('valid_user', "Please specify a valid user.");
+define('enter_valid_username', "Please enter a valid username.");
+define('unexpected_role', "Unexpected user role received.");
 ?>

--- a/lang/English/modules/user_games.php
+++ b/lang/English/modules/user_games.php
@@ -210,4 +210,5 @@ define('level_up', "Level up");
 define('level_up_info', "Back to the previous folder.");
 define('add_folder', "Add folder");
 define('add_folder_info', "Write the name for the new folder, then click on the icon.");
+define('valid_user', "Please specify a valid user.");
 ?>

--- a/lang/French/modules/gamemanager.php
+++ b/lang/French/modules/gamemanager.php
@@ -185,4 +185,5 @@ define('directory', "Directory");
 define('view_player_commands', "Voir Commandes Joueur");
 define('hide_player_commands', "Cacher Commandes Joueur");
 define('no_online_players', "Il n'y a pas de joueurs en ligne.");
+define('invalid_game_mod_id', "Invalid game/mod id specified.");
 ?>

--- a/lang/French/modules/user_admin.php
+++ b/lang/French/modules/user_admin.php
@@ -102,4 +102,8 @@ define('group_with_id_does_not_exist', "Le Groupe avec l'ID %s n'existe pas.");
 define('are_you_sure_you_want_to_delete_group', "Etes-vous sûr de vouloir supprimer le Groupe <em>%s</em> ?");
 define('unable_to_delete_group', "Impossible de supprimer le Groupe %s.");
 define('successfully_deleted_group', "Groupe <b>%s</b> supprimé avec succès.");
+define('editing_profile', "Editing Profile: %s");
+define('valid_user', "Please specify a valid user.");
+define('enter_valid_username', "Please enter a valid username.");
+define('unexpected_role', "Unexpected user role received.");
 ?>

--- a/lang/French/modules/user_games.php
+++ b/lang/French/modules/user_games.php
@@ -210,4 +210,5 @@ define('level_up', "^ Dossier parent ^");
 define('level_up_info', "Retour au dossier précédent.");
 define('add_folder', "Créer un dossier");
 define('add_folder_info', "Écrire le nom du nouveau dossier, puis cliquer sur l'icône.");
+define('valid_user', "Please specify a valid user.");
 ?>

--- a/lang/German/modules/gamemanager.php
+++ b/lang/German/modules/gamemanager.php
@@ -185,4 +185,5 @@ define('directory', "Ordner-Pfad");
 define('view_player_commands', "View Player Commands");
 define('hide_player_commands', "Hide Player Commands");
 define('no_online_players', "There are no online players.");
+define('invalid_game_mod_id', "Invalid game/mod id specified.");
 ?>

--- a/lang/German/modules/user_admin.php
+++ b/lang/German/modules/user_admin.php
@@ -102,4 +102,8 @@ define('group_with_id_does_not_exist', "%s group does not exist.");
 define('are_you_sure_you_want_to_delete_group', "Are you sure you want to delete group <em>%s</em>?");
 define('unable_to_delete_group', "Unable to delete %s group.");
 define('successfully_deleted_group', "Successfully deleted group <b>%s</b>.");
+define('editing_profile', "Editing Profile: %s");
+define('valid_user', "Please specify a valid user.");
+define('enter_valid_username', "Please enter a valid username.");
+define('unexpected_role', "Unexpected user role received.");
 ?>

--- a/lang/German/modules/user_games.php
+++ b/lang/German/modules/user_games.php
@@ -210,4 +210,5 @@ define('level_up', "Level up");
 define('level_up_info', "Zurück zum vorherigen Ordner.");
 define('add_folder', "Ordner hinzufügen");
 define('add_folder_info', "Write the name for the new folder, then click on the icon.");
+define('valid_user', "Please specify a valid user.");
 ?>

--- a/lang/Hungarian/modules/gamemanager.php
+++ b/lang/Hungarian/modules/gamemanager.php
@@ -185,4 +185,5 @@ define('directory', "Könyvtár");
 define('view_player_commands', "Játékos parancsok mutatása");
 define('hide_player_commands', "Játékos parancsok elrejtése");
 define('no_online_players', "Nincsenek online játékosok.");
+define('invalid_game_mod_id', "Invalid game/mod id specified.");
 ?>

--- a/lang/Hungarian/modules/user_admin.php
+++ b/lang/Hungarian/modules/user_admin.php
@@ -102,4 +102,8 @@ define('group_with_id_does_not_exist', "A(z) %s csoport nem létezik.");
 define('are_you_sure_you_want_to_delete_group', "Are you sure you want to delete group <em>%s</em>?");
 define('unable_to_delete_group', "Nem lehet törölni a(z) %s csoportot.");
 define('successfully_deleted_group', "Sikeresen törölve a(z) <br>%s<br> csoport.");
+define('editing_profile', "Editing Profile: %s");
+define('valid_user', "Please specify a valid user.");
+define('enter_valid_username', "Please enter a valid username.");
+define('unexpected_role', "Unexpected user role received.");
 ?>

--- a/lang/Hungarian/modules/user_games.php
+++ b/lang/Hungarian/modules/user_games.php
@@ -210,4 +210,5 @@ define('level_up', "Szintlépés");
 define('level_up_info', "Back to the previous folder.");
 define('add_folder', "Mappa hozzáadása");
 define('add_folder_info', "Write the name for the new folder, then click on the icon.");
+define('valid_user', "Please specify a valid user.");
 ?>

--- a/lang/Polish/modules/gamemanager.php
+++ b/lang/Polish/modules/gamemanager.php
@@ -185,4 +185,5 @@ define('directory', "ĹšcieĹĽka katalogu");
 define('view_player_commands', "View Player Commands");
 define('hide_player_commands', "Hide Player Commands");
 define('no_online_players', "There are no online players.");
+define('invalid_game_mod_id', "Invalid game/mod id specified.");
 ?>

--- a/lang/Polish/modules/user_admin.php
+++ b/lang/Polish/modules/user_admin.php
@@ -102,4 +102,8 @@ define('group_with_id_does_not_exist', "Grupa o ID %s nie istnieje.");
 define('are_you_sure_you_want_to_delete_group', "Czy na pewno chcesz usunąć grupę");
 define('unable_to_delete_group', "Nie można usunąć %s grupy.");
 define('successfully_deleted_group', "Grupa z powodzeniem usunięta");
+define('editing_profile', "Editing Profile: %s");
+define('valid_user', "Please specify a valid user.");
+define('enter_valid_username', "Please enter a valid username.");
+define('unexpected_role', "Unexpected user role received.");
 ?>

--- a/lang/Polish/modules/user_games.php
+++ b/lang/Polish/modules/user_games.php
@@ -210,4 +210,5 @@ define('level_up', "Do góry");
 define('level_up_info', "Powrót do poprzedniego folderu.");
 define('add_folder', "Dodaj Folder");
 define('add_folder_info', "Wpisz nazwę nowego folderu, a następnie kliknij na ikonę.");
+define('valid_user', "Please specify a valid user.");
 ?>

--- a/lang/Portuguese/modules/gamemanager.php
+++ b/lang/Portuguese/modules/gamemanager.php
@@ -185,4 +185,5 @@ define('directory', "Directory");
 define('view_player_commands', "View Player Commands");
 define('hide_player_commands', "Hide Player Commands");
 define('no_online_players', "There are no online players.");
+define('invalid_game_mod_id', "Invalid game/mod id specified.");
 ?>

--- a/lang/Portuguese/modules/user_admin.php
+++ b/lang/Portuguese/modules/user_admin.php
@@ -106,6 +106,4 @@ define('editing_profile', "Editing Profile: %s");
 define('valid_user', "Please specify a valid user.");
 define('enter_valid_username', "Please enter a valid username.");
 define('unexpected_role', "Unexpected user role received.");
-define('enter_valid_username', "Please enter a valid username.");
-define('unexpected_role', "Unexpected user role received.");
 ?>

--- a/lang/Portuguese/modules/user_admin.php
+++ b/lang/Portuguese/modules/user_admin.php
@@ -102,4 +102,10 @@ define('group_with_id_does_not_exist', "%s group does not exist.");
 define('are_you_sure_you_want_to_delete_group', "Are you sure you want to delete group <em>%s</em>?");
 define('unable_to_delete_group', "Unable to delete %s group.");
 define('successfully_deleted_group', "Successfully deleted group <b>%s</b>.");
+define('editing_profile', "Editing Profile: %s");
+define('valid_user', "Please specify a valid user.");
+define('enter_valid_username', "Please enter a valid username.");
+define('unexpected_role', "Unexpected user role received.");
+define('enter_valid_username', "Please enter a valid username.");
+define('unexpected_role', "Unexpected user role received.");
 ?>

--- a/lang/Portuguese/modules/user_games.php
+++ b/lang/Portuguese/modules/user_games.php
@@ -210,4 +210,5 @@ define('level_up', "Level up");
 define('level_up_info', "Back to the previous folder.");
 define('add_folder', "Add folder");
 define('add_folder_info', "Write the name for the new folder, then click on the icon.");
+define('valid_user', "Please specify a valid user.");
 ?>

--- a/lang/Russian/modules/gamemanager.php
+++ b/lang/Russian/modules/gamemanager.php
@@ -185,4 +185,5 @@ define('directory', "Путь к каталогу");
 define('view_player_commands', "View Player Commands");
 define('hide_player_commands', "Hide Player Commands");
 define('no_online_players', "There are no online players.");
+define('invalid_game_mod_id', "Invalid game/mod id specified.");
 ?>

--- a/lang/Russian/modules/user_admin.php
+++ b/lang/Russian/modules/user_admin.php
@@ -102,4 +102,6 @@ define('group_with_id_does_not_exist', "%s group does not exist.");
 define('are_you_sure_you_want_to_delete_group', "Are you sure you want to delete group <em>%s</em>?");
 define('unable_to_delete_group', "Unable to delete %s group.");
 define('successfully_deleted_group', "Successfully deleted group <b>%s</b>.");
+define('editing_profile', "Editing Profile: %s");
+define('valid_user', "Please specify a valid user.");
 ?>

--- a/lang/Russian/modules/user_admin.php
+++ b/lang/Russian/modules/user_admin.php
@@ -104,4 +104,5 @@ define('unable_to_delete_group', "Unable to delete %s group.");
 define('successfully_deleted_group', "Successfully deleted group <b>%s</b>.");
 define('editing_profile', "Editing Profile: %s");
 define('valid_user', "Please specify a valid user.");
+define('unexpected_role', "Unexpected user role received.");
 ?>

--- a/lang/Russian/modules/user_games.php
+++ b/lang/Russian/modules/user_games.php
@@ -210,4 +210,5 @@ define('level_up', "Level up");
 define('level_up_info', "Back to the previous folder.");
 define('add_folder', "Add folder");
 define('add_folder_info', "Write the name for the new folder, then click on the icon.");
+define('valid_user', "Please specify a valid user.");
 ?>

--- a/lang/Spanish/modules/gamemanager.php
+++ b/lang/Spanish/modules/gamemanager.php
@@ -185,4 +185,5 @@ define('directory', "Ruta del Directorio");
 define('view_player_commands', "Ver Comandos De Jugadores");
 define('hide_player_commands', "Ocultar Comandos De Jugadores");
 define('no_online_players', "No hay jugadores en linea.");
+define('invalid_game_mod_id', "Invalid game/mod id specified.");
 ?>

--- a/lang/Spanish/modules/user_admin.php
+++ b/lang/Spanish/modules/user_admin.php
@@ -102,4 +102,8 @@ define('group_with_id_does_not_exist', "No existe ningun grupo con ID %s.");
 define('are_you_sure_you_want_to_delete_group', "Esta seguro que desea eliminar el grupo %s");
 define('unable_to_delete_group', "Imposible eliminar el grupo %s.");
 define('successfully_deleted_group', "Grupo %s eliminado correctamente.");
+define('editing_profile', "Editing Profile: %s");
+define('valid_user', "Please specify a valid user.");
+define('enter_valid_username', "Please enter a valid username.");
+define('unexpected_role', "Unexpected user role received.");
 ?>

--- a/lang/Spanish/modules/user_games.php
+++ b/lang/Spanish/modules/user_games.php
@@ -210,4 +210,5 @@ define('level_up', "Subir un nivel");
 define('level_up_info', "Volver a la carpeta anterior.");
 define('add_folder', "Añadir carpeta");
 define('add_folder_info', "Escriba aquí el nombre para la nueva carpeta, después haga click sobre el icono.");
+define('valid_user', "Please specify a valid user.");
 ?>

--- a/modules/administration/watch_logger.php
+++ b/modules/administration/watch_logger.php
@@ -32,7 +32,7 @@ function exec_ogp_module() {
 	<table class="center">
 	<tr>
 	<td>
-	<form>
+	<form onsubmit="event.preventDefault();">
 		<b><?php print_lang('search'); ?>:</b>
 		<input type="text" id="search">
 	</form>

--- a/modules/gamemanager/rcon.php
+++ b/modules/gamemanager/rcon.php
@@ -99,7 +99,7 @@ if($presets > 0)
 	<form method="post">
 	<input class="rcon" type="text" name="command" size="200" style="width:98%;" value='<?php 
 	if( isset($_POST['command']) )
-		echo $_POST['command'][0];
+		echo htmlentities($_POST['command'][0]);
 	?>' />
   </td>
   <td>
@@ -125,7 +125,7 @@ if(isset($_POST['remote_send_rcon_command']))
 	}
 	if($response)
 	{
-		echo "<div class='bloc' ><h4>" . rcon_command_title . ": [" . implode(" | ", $_POST['command']) . "] " .
+		echo "<div class='bloc' ><h4>" . rcon_command_title . ": [" . htmlentities(implode(" | ", $_POST['command'])) . "] " .
 			 has_sent_to . " " . $home_info['home_name'] . "</h4><xmp style='overflow:scroll;' >" . 
 			 $response . "</xmp></div>";
 	}

--- a/modules/gamemanager/rcon_presets.php
+++ b/modules/gamemanager/rcon_presets.php
@@ -54,6 +54,11 @@ function exec_ogp_module() {
 		$home_cfg_id = $current_mod_info['home_cfg_id'];
 		$mod_cfg_id = $current_mod_info['mod_cfg_id'];
 		
+		if($home_cfg_id === null && $mod_cfg_id === null){
+			print_failure(get_lang('invalid_game_mod_id'));
+			return;
+		}
+		
 		echo "<h2>".get_lang_f( "presets_for_game_and_mod",$game,$mod)."</h2>";
 		
 		if(isset($_POST['add_rcon_preset']))

--- a/modules/gamemanager/server_monitor.php
+++ b/modules/gamemanager/server_monitor.php
@@ -178,7 +178,7 @@ function exec_ogp_module() {
 
 	require("protocol/lgsl/lgsl_protocol.php");
 	?>
-		<form>
+		<form onsubmit="event.preventDefault();">
 			<b><?php print_lang('search'); ?>:</b>
 			<input type="text" id="search">
 		</form>

--- a/modules/gamemanager/view_server_log.php
+++ b/modules/gamemanager/view_server_log.php
@@ -41,6 +41,15 @@ function exec_ogp_module()
 	else
 		$home_info = $db->getUserGameHome($user_id,$home_id);
 	
+	$current_mod_info = $home_info['mods'][$mod_id];	
+	$home_cfg_id = $current_mod_info['home_cfg_id'];
+	$mod_cfg_id = $current_mod_info['mod_cfg_id'];
+	
+	if($home_cfg_id === null && $mod_cfg_id === null){
+		print_failure(get_lang('invalid_game_mod_id'));
+		return;
+	}
+	
     if ( $home_info === FALSE )
     {
         print_failure( no_access_to_home );

--- a/modules/user_admin/add_user.php
+++ b/modules/user_admin/add_user.php
@@ -28,11 +28,26 @@ function exec_ogp_module()
     global $view;
     if( isset($_POST['submit']) )
     {
-        $username = trim($_POST['username']);
+        $username = sanitizeInputStr($_POST['username']);
         $user_role = trim($_POST['user_role']);
         $password = trim($_POST['newpass']);
         $password2 = trim($_POST['newpass2']);
-
+		
+		// Check a username is actually entered...
+		if(empty($username) === true){
+			print_failure(get_lang('enter_valid_username'));
+			$view->refresh("?m=user_admin");
+			return;
+		}
+		
+		// Check _POST['user_role'] is what we expect it to be: either user or admin.
+		// Without this it can be anything else. It's pointless being anything else - but why allow it to be anything else?
+		if(in_array($_POST['user_role'], array('user', 'admin')) === false){
+			print_failure(get_lang('unexpected_role'));
+			$view->refresh("?m=user_admin");
+			return;
+		}
+		
         if( empty($password) || empty($password2) )
         {
             print_failure(get_lang('you_need_to_enter_both_passwords'));

--- a/modules/user_admin/show_users.php
+++ b/modules/user_admin/show_users.php
@@ -80,8 +80,8 @@ function exec_ogp_module() {
             get_lang('assign_homes')."]</a><br />
             <a href='?m=user_admin&amp;p=del&amp;user_id=$row[user_id]'>[".get_lang('delete')."]</a><br />
             <a href='?m=user_admin&amp;p=edit_user&amp;user_id=$row[user_id]'>[".get_lang('edit_profile')."]</a></td>
-            <td>$row[users_login]</td><td>$row[users_role]</td>
-            <td>$row[users_email]</td>
+            <td>".htmlentities($row['users_login'])."</td><td>".htmlentities($row['users_role'])."</td>
+            <td>".htmlentities($row['users_email'])."</td>
             <td>$user_expires</td>";
         if(!empty($ownedBy)){
 			print "<td></td>";

--- a/modules/user_games/assign_home.php
+++ b/modules/user_games/assign_home.php
@@ -38,6 +38,12 @@ function exec_ogp_module()
 	
 	$isAdmin = $db->isAdmin($_SESSION['user_id']);
 	
+	if(empty($_REQUEST['user_id']) === true || $db->getUserById($_REQUEST['user_id']) === null)
+	{
+		print_failure(get_lang('valid_user'));
+		return;
+	}
+	
 	if ( isset( $_REQUEST['user_id'] ) && !$isAdmin )
 	{
 		echo "<p class='note'>".get_lang('not_available')."</p>";


### PR DESCRIPTION
Changes:

User_Admin Module:
-Editing another users profile will now show their username in the header rather than "Your Profile", applies for sub-accounts too.

-In show_users: Wrapped htmlentities() around user_login, user_role, and users_email for other non-tag related entities, ie, &amp;

-Added validation to add_user:
--Tags are stripped on usernames to match sub-users and the register function.
--Check if the username is empty before adding the user.
--Check if the user_role is either user or admin before adding the user, preventing form manipulation.

User_Games Module:
Checked the user_id parameter in the URI to make sure it corresponds to a valid user before assigning user_id to a home.

Gamemanager Module:
-Prevented an SQL error showing on the RCON presets page when the URI has been changed by checking if $home_cfg_id and $mod_cfg_id are null or not.

-Prevented an SQL error showing on the view_server_log page when the URI has been changed by checking if $home_cfg_id and $mod_cfg_id are null or not.

-Added htmlentities() around the displayed command on the RCON page to the user. Rationale: Without it iframes could be embedded in some browsers - and a less experienced user just pasting what they assume to be commands in, might actually be HTML - thus, XSS.

-Prevented default behaviour of the server search form in server_monitor.php - without this, if you hit enter you'll be directed to a blank page.

Administration Module:

-Prevented default behaviour of the log search form in watch_logger.php - without this, if you hit enter you'll be directed to a blank page.

database_mysqli.php and database_mysql.php:
-Fixed getUsersSubUsersIds() not checking the return value of listQuery. If listQuery returns false then a warning is given as you cannot pass false to foreach()