### PR TITLE
Better Killing Floor 2 support

### DIFF
--- a/modules/config_games/server_configs/killingfloor2_win64.xml
+++ b/modules/config_games/server_configs/killingfloor2_win64.xml
@@ -1,19 +1,21 @@
-<game_config> 
+<game_config>
   <game_key>killingfloor2_win64</game_key>
   <protocol>lgsl</protocol>
-  <lgsl_query_name>redorchestra2</lgsl_query_name>
+  <lgsl_query_name>kf2</lgsl_query_name>
   <installer>steamcmd</installer>
   <game_name>Killing Floor 2</game_name>
   <server_exec_name>KFServer.exe</server_exec_name>
-  <cli_template>%MAP%%GAMEMODE%%DIFFICULTY%%GAMELENGTH%%PLAYERS% %PORT% %IP% %WEB_ADMIN_PORT%</cli_template>
+  <cli_template>%MAP%%GAMEMODE%%DIFFICULTY%%GAMELENGTH%%PLAYERS%%IP%%PORT%%QUERY_PORT%%WEB_ADMIN_PORT%</cli_template>
   <cli_params>
     <cli_param id="MAP" cli_string="" />
-    <cli_param id="IP" cli_string="-MultiHome=" />
-    <cli_param id="PORT" cli_string="-Port=" />
-	<cli_param id="PLAYERS" cli_string="?MaxPlayers=" />
+    <cli_param id="IP" cli_string="?MultiHome=" />
+    <cli_param id="PORT" cli_string="?Port=" />
+    <cli_param id="PLAYERS" cli_string="?MaxPlayers=" />
+    <cli_param id="CONTROL_PASSWORD" cli_string="?AdminPassword=" />
   </cli_params>
   <reserve_ports>
-    <port type="add" id="WEB_ADMIN_PORT" cli_string="-WebAdminPort=">10</port>
+    <port type="add" id="QUERY_PORT" cli_string="?QueryPort=">1</port>
+    <port type="add" id="WEB_ADMIN_PORT" cli_string="?WebAdminPort=">2</port>
   </reserve_ports>
   <map_list>maplist.txt</map_list>
   <console_log>KFGame/Logs/Launch.log</console_log>
@@ -22,7 +24,7 @@
   <mods>
     <mod key="killingfloor2">
       <name>none</name>
-      <installer_name>232130</installer_name> 
+      <installer_name>232130</installer_name>
       <installer_login>anonymous</installer_login>
     </mod>
   </mods>
@@ -49,27 +51,27 @@
     <param id="GAMEMODE" key="?Game=" type="text">
       <option>ns</option>
       <caption>Game Mode</caption>
-      <desc>Leave empty to run the normal game mode.&lt;br&gt;To run your server with official Versus Survival mode use this:&lt;br&gt;&lt;br&gt;KFGameContent.KFGameInfo_VersusSurvival&lt;br&gt;&lt;br&gt;You can use any other gametype if you installed any other mod from Steam Workshop</desc>
+      <desc>Leave empty to run the normal game mode.&lt;br&gt;To run your server with official Versus Survival mode use this:&lt;br&gt;&lt;br&gt;KFGameContent.KFGameInfo_VersusSurvival&lt;br&gt;&lt;br&gt;You can use any other gametype i$
     </param>
   </server_params>
   <post_install>
-		maplist="maplist.txt"
-		if [ -s "$maplist" ]
-		then
-		echo "File $maplist found. OK!"
-		else
-		echo "File $maplist not found"
-		echo "Generating new maplist file in $maplist"
-		touch maplist.txt
-		echo KF-BioticsLab > maplist.txt
-		echo KF-BlackForest >> maplist.txt
-		echo KF-BurningParis >> maplist.txt
-		echo KF-Catacombs >> maplist.txt
-		echo KF-EvacuationPoint >> maplist.txt
-		echo KF-Farmhouse >> maplist.txt
-		echo KF-VolterManor >> maplist.txt
-		echo KF-Outpost >> maplist.txt
-		echo KF-Prison >> maplist.txt
-		fi
-	</post_install>
+                maplist="maplist.txt"
+                if [ -s "$maplist" ]
+                then
+                echo "File $maplist found. OK!"
+                else
+                echo "File $maplist not found"
+                echo "Generating new maplist file in $maplist"
+                touch maplist.txt
+                echo KF-BioticsLab > maplist.txt
+                echo KF-BlackForest >> maplist.txt
+                echo KF-BurningParis >> maplist.txt
+                echo KF-Catacombs >> maplist.txt
+                echo KF-EvacuationPoint >> maplist.txt
+                echo KF-Farmhouse >> maplist.txt
+                echo KF-VolterManor >> maplist.txt
+                echo KF-Outpost >> maplist.txt
+                echo KF-Prison >> maplist.txt
+                fi
+        </post_install>
 </game_config>

--- a/modules/config_games/server_configs/killingfloor2_win64.xml
+++ b/modules/config_games/server_configs/killingfloor2_win64.xml
@@ -51,7 +51,7 @@
     <param id="GAMEMODE" key="?Game=" type="text">
       <option>ns</option>
       <caption>Game Mode</caption>
-      <desc>Leave empty to run the normal game mode.&lt;br&gt;To run your server with official Versus Survival mode use this:&lt;br&gt;&lt;br&gt;KFGameContent.KFGameInfo_VersusSurvival&lt;br&gt;&lt;br&gt;You can use any other gametype i$
+      <desc>Leave empty to run the normal game mode.&lt;br&gt;To run your server with official Versus Survival mode use this:&lt;br&gt;&lt;br&gt;KFGameContent.KFGameInfo_VersusSurvival&lt;br&gt;&lt;br&gt;You can use any other gametype if you installed any other mod from Steam Workshop</desc>
     </param>
   </server_params>
   <post_install>

--- a/protocol/lgsl/lgsl_protocol.php
+++ b/protocol/lgsl/lgsl_protocol.php
@@ -80,6 +80,7 @@ if (!function_exists('lgsl_version')) { // START OF DOUBLE LOAD PROTECTION
 		"jediknightja"	=> "JediKnight: Jedi Academy",
 		"jc2mp"			=> "Just Cause 2 Multiplayer",
 		"killingfloor"	=> "Killing Floor",
+		"kf2"			=> "Killing Floor 2",
 		"kingpin"		=> "Kingpin: Life of Crime",
 		"lif"			=> "Life is Feudal",
 		"modernwarfare3"=> "CoD: Modern Warfare 3",
@@ -215,6 +216,7 @@ if (!function_exists('lgsl_version')) { // START OF DOUBLE LOAD PROTECTION
 		"jediknightja"	=> "02",
 		"jc2mp"			=> "40",
 		"killingfloor"	=> "13",
+		"kf2"			=> "05",
 		"kingpin"		=> "03",
 		"lif"			=> "05",
 		"modernwarfare3"=> "31",
@@ -358,6 +360,7 @@ if (!function_exists('lgsl_version')) { // START OF DOUBLE LOAD PROTECTION
 		"jediknightja"	=> "qtracker://{IP}:{S_PORT}?game=JediKnightJediAcademy&action=show",
 		"jc2mp"			=> "steam://connect/{IP}:{S_PORT}",
 		"killingfloor"	=> "steam://connect/{IP}:{C_PORT}",
+		"kf2"	=> "steam://connect/{IP}:{C_PORT}",
 		"kingpin"		=> "qtracker://{IP}:{S_PORT}?game=Kingpin&action=show",
 		"lif"			=> "steam://connect/{IP}:{Q_PORT}",
 		"modernwarfare3"=> "http://en.wikipedia.org/wiki/Call_of_Duty:_Modern_Warfare_3",
@@ -464,6 +467,7 @@ if (!function_exists('lgsl_version')) { // START OF DOUBLE LOAD PROTECTION
 			case "hurtworld"		: $c_to_q = 10;		$c_def = 12871;	$q_def = 12881;	$c_to_s = 0;	break;
 			case "kingpin"			: $c_to_q = -10;	$c_def = 31510;	$q_def = 31500;	$c_to_s = 0;	break;
 			case "killingfloor"		: $c_to_q = 1;		$c_def = 7708;	$q_def = 7709;	$c_to_s = 0;	break;
+			case "kf2"				: $c_to_q = 1;		$c_def = 7777;	$q_def = 27015;	$c_to_s = 0;	break;
 			case "lif"				: $c_to_q = 2;		$c_def = 28000; $q_def = 28002; $c_to_s = 0;	break;
 			case "modernwarfare3"	: $c_to_q = -1;		$c_def = 27015;	$q_def = 27014;	$c_to_s = 0;	break;
 			case "mohaa"			: $c_to_q = 97;		$c_def = 12203;	$q_def = 12300;	$c_to_s = 0;	break;


### PR DESCRIPTION
- Added LGSL config for KF2 
- Changed KF2 config, adding / changing the following:
  - Changed port mapping so that one could run several KF2 servers. Example:
    - Game Port: 7777 (Default: 7777)
    - Query Port: Game Port +1 (Default: 27015)
    - Web Admin Port: Game Port + 2 (Default: 8080)
- Did some general cleanup to keep the UT-Style args clean.