### PR TITLE
Fix for rcon preset form

### DIFF
--- a/modules/gamemanager/rcon.php
+++ b/modules/gamemanager/rcon.php
@@ -85,6 +85,7 @@ if($presets > 0)
 	{
 		echo '<option value="'.$preset['command'].'" >'.$preset['name'].'</option>\n';
 	}
+	echo '<input type="hidden" name="remote_send_rcon_command" value="">';
 	echo '</form>';
 }
 ?>


### PR DESCRIPTION
Form is missing "remote_send_rcon_command" field so commands weren't actually executed upon site load. Added hidden input for it.