### PR TITLE
Assigning Multiple Cores to Servers

### DIFF
--- a/js/modules/user_games-mods.js
+++ b/js/modules/user_games-mods.js
@@ -6,9 +6,17 @@ $('.set_options').click(function(){
 	var mod_cfg_id = $(this).attr('id');
 	var modtr = $('#mod_cfg_id_'+mod_cfg_id);
 	var addpost = {};
+	
+	var cpus = [];
+
+	$("#cpu_select").find('.cpus:checked').each(function(i, e) {
+		cpus.push($(this).val());
+		addpost['cpus'] = cpus.join();
+	});
+
 	addpost[ 'set_options' ] = 1;
 	addpost[ 'cliopts' ] = modtr.find('#cliopts').val();
-	addpost[ 'cpus' ] = modtr.find('#cpus').val();
+
 	addpost[ 'nice' ] = modtr.find('#nice').val();
 	addpost[ 'mod_cfg_id' ] = mod_cfg_id;
 	if( modtr.find('#maxplayers').get(0) )

--- a/lang/English/modules/user_games.php
+++ b/lang/English/modules/user_games.php
@@ -212,4 +212,5 @@ define('add_folder', "Add folder");
 define('add_folder_info', "Write the name for the new folder, then click on the icon.");
 define('valid_user', "Please specify a valid user.");
 define('valid_group', "Please specify a valid group.");
+define('set_affinity', 'Set Server Affinity')
 ?>

--- a/modules/user_games/edit_home.php
+++ b/modules/user_games/edit_home.php
@@ -504,8 +504,35 @@ function exec_ogp_module()
 		{
 			$maxplayers = 0 + @$_POST['maxplayers'];
 			$cliopts = $_POST['cliopts'];
-			$cpus = $_POST['cpus'];
-			$nice = $_POST['nice'];
+
+			// Get the total CPU count. and, if the agent is offline, set the CPU to NA.
+			$remoteCpus = $remote->cpu_count();
+			$validCpus = $remoteCpus === -1 ? 'NA' : $remoteCpus-1;
+
+			if(isset($_POST['cpus']) && $validCpus !== 'NA')
+			{
+				$cpuArray = explode(',', $_POST['cpus']);
+
+				// Check if a a valid core has been submitted. eg, the checkbox hasn't been manually edited.
+				foreach($cpuArray as $cpu)
+				{
+					if($cpu > $validCpus || !is_numeric($cpu))
+					{
+						$cpus = 'NA';
+						break;
+					} else {
+						$cpus[] = $cpu;
+					}
+				}
+
+				// If $cpus is an array, seperate all the values with a comma. Otherwise, just pass $cpus to the query - which, as above, will be NA.
+				$cpus = is_array($cpus) ? implode(',', $cpus) : $cpus;
+
+			} else {
+				$cpus = 'NA';
+			}
+
+			$nice = isset($_POST['nice']) ? (int)$_POST['nice'] : 0;
 			$mod_cfg_id = $_POST['mod_cfg_id'];
 
 			if ( $db->updateGameModParams($maxplayers,$cliopts,$cpus,$nice,$home_id,$mod_cfg_id) === TRUE )

--- a/modules/user_games/edit_home.php
+++ b/modules/user_games/edit_home.php
@@ -532,6 +532,21 @@ function exec_ogp_module()
 				$cpus = 'NA';
 			}
 
+			// If we're on Windows, and some cores have been selected...
+			if(preg_match('/win/', $remote->what_os()) && $cpus !== 'NA')
+			{
+				$result = 0;
+				$cores = explode(',', $cpus);
+
+				foreach ($cores as $core)
+				{
+					$coreNum = intval($core);
+					$result |= (1 << $coreNum);
+				}
+
+				$cpus = dechex($result);
+			}
+
 			$nice = isset($_POST['nice']) ? (int)$_POST['nice'] : 0;
 			$mod_cfg_id = $_POST['mod_cfg_id'];
 

--- a/modules/user_games/home_mods.php
+++ b/modules/user_games/home_mods.php
@@ -93,15 +93,14 @@ function exec_ogp_module()
 	if( !empty($enabled_mods) )
 	{
 		$cpu_count = $remote->cpu_count();
+		
 		if($cpu_count === -1)
 		{
 			print_failure( warning_agent_offline_defaulting_CPU_count_to_1 );
 			$cpu_count = 'NA';
-		}
-		else
-		{
+		} else {
 			// cpu numbering starts from 0 so lets remove the last cpu.
-			$cpu_count -= 1;
+			--$cpu_count;
 		}
 
 		echo "<table class='center'>\n".
@@ -111,7 +110,6 @@ function exec_ogp_module()
 		if ( $server_xml->max_user_amount )
 			echo "<td><b>". max_players ."</b></td>";
 		echo "<td><b>". extra_cmd_line_args ."</b></td>".
-			 "<td><b>". cpu_affinity ."</b></td>".
 			 "<td><b>". nice_level ."</b></td><td></td>".
 			 "</tr>\n";
 		foreach ( $enabled_mods as $enabled_rows ) {
@@ -130,17 +128,28 @@ function exec_ogp_module()
 			}
 			echo "<input id='cliopts' type='text' name='cliopts' size='20' value=\"".
 				 str_replace('"', "&quot;", strip_real_escape_string($enabled_rows['extra_params']))."\" />".
-				 "</td><td>\n".
-				 create_drop_box_from_array(array_merge(array('NA'),range(0,$cpu_count)),
-				 'cpus',$enabled_rows['cpu_affinity']).
-				 "</td><td>\n".
-				 create_drop_box_from_array(array_merge(range(-19,19)),
+				 "</td><td>\n";
+
+				 echo create_drop_box_from_array(array_merge(range(-19,19)),
 				 'nice',$enabled_rows['nice']).
 				 "</td><td>\n".
 				 "<button class='set_options' id='$enabled_rows[mod_cfg_id]' >". set_options ."</button>\n".
 				 "</td></tr>\n";
+
 		}
-		echo "</table>\n";
+			
+		echo '</table>';
+
+		echo '<h2>'.get_lang('cpu_affinity').'</h2>';
+		echo '<div id="cpu_select">';
+		
+		for($x = 0; $x <= $cpu_count; ++$x)
+		{
+			echo '<span style="display:inline-block;"><label for="cpu_'.$x.'">CPU '.$x.'</label> <input type="checkbox" name="cpus[]" value="'.$x.'" id="cpu_'.$x.'" class="cpus" /></span>';
+		}
+		
+		echo '</div><button class="set_options" id="'.$enabled_rows['mod_cfg_id'].'" style="float:right">'.get_lang('set_affinity').'</button>';
+
 		$game_mods = $db->getAvailableModsForGameHome($home_id);
 		$mods_available = 0;
 		foreach ( $game_mods as $game_mod )

--- a/modules/user_games/module.php
+++ b/modules/user_games/module.php
@@ -25,7 +25,7 @@
 // Module general information
 $module_title = "User games";
 $module_version = "1.3";
-$db_version = 2;
+$db_version = 3;
 $module_required = TRUE;
 $module_menus = array(
 	array( 'subpage' => '', 'name'=>'Game Servers', 'group'=>'admin' )
@@ -66,4 +66,8 @@ $install_queries[1] = array(
 $install_queries[2] = array(
 	"ALTER TABLE `".OGP_DB_PREFIX."user_homes` ADD `user_expiration_date` VARCHAR(21) NOT NULL default 'X';",
 	"ALTER TABLE `".OGP_DB_PREFIX."user_group_homes` ADD `user_group_expiration_date` VARCHAR(21) NOT NULL default 'X';");
+
+$install_queries[3] = array(
+	"ALTER TABLE `".OGP_DB_PREFIX."game_mods` modify column `cpu_affinity` varchar(64) null AFTER `extra_params`, comment = 'utf8mb4_general_ci'";
+	);
 ?>


### PR DESCRIPTION
Fulfilling a feature request posted [here](http://www.opengamepanel.org/forum/viewthread.php?thread_id=5285) by @FarukGamer - these small changes allow you to assign multiple cores to a server.

It requires a change in the ogp_game_mods table, changing the cpu_affinity column from a varchar(2) to varchar(64) (a maximum possible of 32 cores, as the core info is seperated by commas, eg, 0,1,2)

It doesn't require anything to be changed on the agent side - as the agent just uses `taskset`, which accepts cores the way I mentioned above.

It'll also attempt to verify that a valid core has been selected. As in, if you've got 4 cores, the user cannot edit the checkboxes and change the value of one to a non-existing core. Or edit the checkbox value to a
non-numeric value. Doing so will default the field to 'NA', which the agent handles.

It's mostly srcds servers I've hosted for in the past which don't benefit from multiple cores. Although, I could see this being useful for some games.