### PR TITLE
AppID fixes

### DIFF
--- a/modules/config_games/server_configs/space_engineers_win32.xml
+++ b/modules/config_games/server_configs/space_engineers_win32.xml
@@ -1,44 +1,43 @@
 <game_config>
-<game_key>space_engineers_win32</game_key>
-<protocol>lgsl</protocol>
-<lgsl_query_name>source</lgsl_query_name>
-<installer>steamcmd</installer>
-<game_name>Space Engineers</game_name>
-<server_exec_name>SpaceEngineersDedicated.exe</server_exec_name>
-<cli_template>-console %BASE_PATH% -ignorelastsession</cli_template>
-<cli_params>  
- <cli_param id="BASE_PATH" cli_string="-path" options="sq" />
-</cli_params>
-<console_log>SpaceEngineersDedicated.log</console_log>
-<exe_location>DedicatedServer</exe_location>
-<max_user_amount>32</max_user_amount>
-<mods>
- <mod key='space_engineers'>
-  <name>none</name>
-  <installer_name>244850</installer_name>
- </mod>
-</mods>
-<replace_texts>
- <text key="home_name">
-  <default>ServerName</default>
-  <filepath>SpaceEngineers-Dedicated.cfg</filepath>
-  <options>tags</options>
- </text>
- <text key="ip">
-  <default>IP</default>
-  <filepath>SpaceEngineers-Dedicated.cfg</filepath>
-  <options>tags</options>
- </text>
- <text key="port">
-  <default>ServerPort</default>
-  <filepath>SpaceEngineers-Dedicated.cfg</filepath>
-  <options>tags</options>
- </text>
- <text key="max_players">
-  <default>MaxPlayers</default>
-  <filepath>SpaceEngineers-Dedicated.cfg</filepath>
-  <options>tags</options>
- </text>
-</replace_texts>
+	<game_key>space_engineers_win32</game_key>
+	<protocol>lgsl</protocol>
+	<lgsl_query_name>source</lgsl_query_name>
+	<installer>steamcmd</installer>
+	<game_name>Space Engineers</game_name>
+	<server_exec_name>SpaceEngineersDedicated.exe</server_exec_name>
+	<cli_template>-console %BASE_PATH% -ignorelastsession</cli_template>
+	<cli_params>  
+		<cli_param id="BASE_PATH" cli_string="-path" options="sq" />
+	</cli_params>
+	<console_log>SpaceEngineersDedicated.log</console_log>
+	<exe_location>DedicatedServer</exe_location>
+	<max_user_amount>32</max_user_amount>
+	<mods>
+		<mod key='space_engineers'>
+			<name>none</name>
+			<installer_name>298740</installer_name>
+	 </mod>
+	</mods>
+	<replace_texts>
+		<text key="home_name">
+			<default>ServerName</default>
+			<filepath>SpaceEngineers-Dedicated.cfg</filepath>
+			<options>tags</options>
+		</text>
+		<text key="ip">
+			<default>IP</default>
+			<filepath>SpaceEngineers-Dedicated.cfg</filepath>
+			<options>tags</options>
+		</text>
+		<text key="port">
+			<default>ServerPort</default>
+			<filepath>SpaceEngineers-Dedicated.cfg</filepath>
+			<options>tags</options>
+		</text>
+		<text key="max_players">
+			<default>MaxPlayers</default>
+			<filepath>SpaceEngineers-Dedicated.cfg</filepath>
+			<options>tags</options>
+		</text>
+	</replace_texts>
 </game_config>
-	

--- a/modules/config_games/server_configs/space_engineers_win64.xml
+++ b/modules/config_games/server_configs/space_engineers_win64.xml
@@ -1,44 +1,43 @@
 <game_config>
-<game_key>space_engineers_win64</game_key>
-<protocol>lgsl</protocol>
-<lgsl_query_name>source</lgsl_query_name>
-<installer>steamcmd</installer>
-<game_name>Space Engineers</game_name>
-<server_exec_name>SpaceEngineersDedicated.exe</server_exec_name>
-<cli_template>-console %BASE_PATH% -ignorelastsession</cli_template>
-<cli_params>  
- <cli_param id="BASE_PATH" cli_string="-path" options="sq" />
-</cli_params>
-<console_log>SpaceEngineersDedicated.log</console_log>
-<exe_location>DedicatedServer64</exe_location>
-<max_user_amount>32</max_user_amount>
-<mods>
- <mod key='space_engineers'>
-  <name>none</name>
-  <installer_name>244850</installer_name>
- </mod>
-</mods>
-<replace_texts>
- <text key="home_name">
-  <default>ServerName</default>
-  <filepath>SpaceEngineers-Dedicated.cfg</filepath>
-  <options>tags</options>
- </text>
- <text key="ip">
-  <default>IP</default>
-  <filepath>SpaceEngineers-Dedicated.cfg</filepath>
-  <options>tags</options>
- </text>
- <text key="port">
-  <default>ServerPort</default>
-  <filepath>SpaceEngineers-Dedicated.cfg</filepath>
-  <options>tags</options>
- </text>
- <text key="max_players">
-  <default>MaxPlayers</default>
-  <filepath>SpaceEngineers-Dedicated.cfg</filepath>
-  <options>tags</options>
- </text>
-</replace_texts>
+	<game_key>space_engineers_win64</game_key>
+	<protocol>lgsl</protocol>
+	<lgsl_query_name>source</lgsl_query_name>
+	<installer>steamcmd</installer>
+	<game_name>Space Engineers</game_name>
+	<server_exec_name>SpaceEngineersDedicated.exe</server_exec_name>
+	<cli_template>-console %BASE_PATH% -ignorelastsession</cli_template>
+	<cli_params>  
+		<cli_param id="BASE_PATH" cli_string="-path" options="sq" />
+	</cli_params>
+	<console_log>SpaceEngineersDedicated.log</console_log>
+	<exe_location>DedicatedServer64</exe_location>
+	<max_user_amount>32</max_user_amount>
+	<mods>
+		<mod key='space_engineers'>
+			<name>none</name>
+			<installer_name>298740</installer_name>
+		</mod>
+	</mods>
+	<replace_texts>
+		<text key="home_name">
+			<default>ServerName</default>
+			<filepath>SpaceEngineers-Dedicated.cfg</filepath>
+			<options>tags</options>
+		</text>
+		<text key="ip">
+			<default>IP</default>
+			<filepath>SpaceEngineers-Dedicated.cfg</filepath>
+			<options>tags</options>
+		</text>
+		<text key="port">
+			<default>ServerPort</default>
+			<filepath>SpaceEngineers-Dedicated.cfg</filepath>
+			<options>tags</options>
+		</text>
+		<text key="max_players">
+			<default>MaxPlayers</default>
+			<filepath>SpaceEngineers-Dedicated.cfg</filepath>
+			<options>tags</options>
+		</text>
+	</replace_texts>
 </game_config>
-	

--- a/modules/config_games/server_configs/starbound_linux64.xml
+++ b/modules/config_games/server_configs/starbound_linux64.xml
@@ -1,67 +1,64 @@
 <game_config>
-  <game_key>starbound_linux64</game_key>
-  <protocol>gameq</protocol>
-  <gameq_query_name>starbound</gameq_query_name>
-  <installer>steamcmd</installer>
-  <game_name>Starbound</game_name>
-  <server_exec_name>starbound_server</server_exec_name>
-  <exe_location>linux</exe_location>
-  <max_user_amount>512</max_user_amount>
-  <mods>
-    <mod key="starbound">
-      <name>none</name>
-      <installer_name>211820</installer_name>
-    </mod>
-  </mods>
-
- <replace_texts>
-    <text key="home_name">
-      <default>"serverName" : "[\w\-\s]*"</default>
-      <var>"serverName" :</var>
-      <filepath>storage/starbound_server.config</filepath>
-      <options>sq</options>
-    </text>
-    <text key="control_password">
-      <default>"rconServerPassword" : "[\w\-\s]*"</default>
-      <var>"rconServerPassword" :</var>
-      <filepath>storage/starbound_server.config</filepath>
-      <options>sq</options>
-    </text>
-    <text key="port">
-      <default>"gameServerPort" : [\w\-\s]*</default>
-      <var>"gameServerPort" :</var>
-      <filepath>storage/starbound_server.config</filepath>
-      <options>s</options>
-    </text>
-    <text key="max_players">
-      <default>"maxPlayers" : [\w\-\s]*</default>
-      <var>"maxPlayers" :</var>
-      <filepath>storage/starbound_server.config</filepath>
-      <options>s</options>
-    </text>
-    <text key="true">
-       <default>"runRconServer" : [\w\-\s]*</default>
-       <var>"runRconServer" : true</var>
-       <filepath>storage/starbound_server.config</filepath>
-       <options></options>
-    </text>
-    <text key="true">
-       <default>"runQueryServer" : [\w\-\s]*</default>
-       <var>"runQueryServer" : true</var>
-       <filepath>storage/starbound_server.config</filepath>
-       <options></options>
-    </text>
-</replace_texts>
-
- <custom_fields>
-    <field key="rconServerPort" type="text">
-       <default>"rconServerPort" : [\w\-\s]*</default>
-       <default_value>21026</default_value>
-       <var>"rconServerPort" :</var>
-       <filepath>storage/starbound_server.config</filepath>
-       <options>s</options>
-       <desc>RCON Server port</desc>
-    </field>
- </custom_fields>
-
+	<game_key>starbound_linux64</game_key>
+	<protocol>gameq</protocol>
+	<gameq_query_name>starbound</gameq_query_name>
+	<installer>steamcmd</installer>
+	<game_name>Starbound</game_name>
+	<server_exec_name>starbound_server</server_exec_name>
+	<exe_location>linux</exe_location>
+	<max_user_amount>512</max_user_amount>
+	<mods>
+		<mod key="starbound">
+			<name>none</name>
+			<installer_name>533830</installer_name>
+		</mod>
+	</mods>
+	<replace_texts>
+		<text key="home_name">
+			<default>"serverName" : "[\w\-\s]*"</default>
+			<var>"serverName" :</var>
+			<filepath>storage/starbound_server.config</filepath>
+			<options>sq</options>
+		</text>
+		<text key="control_password">
+			<default>"rconServerPassword" : "[\w\-\s]*"</default>
+			<var>"rconServerPassword" :</var>
+			<filepath>storage/starbound_server.config</filepath>
+			<options>sq</options>
+		</text>
+		<text key="port">
+			<default>"gameServerPort" : [\w\-\s]*</default>
+			<var>"gameServerPort" :</var>
+			<filepath>storage/starbound_server.config</filepath>
+			<options>s</options>
+		</text>
+		<text key="max_players">
+			<default>"maxPlayers" : [\w\-\s]*</default>
+			<var>"maxPlayers" :</var>
+			<filepath>storage/starbound_server.config</filepath>
+			<options>s</options>
+		</text>
+		<text key="true">
+			<default>"runRconServer" : [\w\-\s]*</default>
+			<var>"runRconServer" : true</var>
+			<filepath>storage/starbound_server.config</filepath>
+			<options></options>
+		</text>
+		<text key="true">
+			<default>"runQueryServer" : [\w\-\s]*</default>
+			<var>"runQueryServer" : true</var>
+			<filepath>storage/starbound_server.config</filepath>
+			<options></options>
+		</text>
+	</replace_texts>
+	<custom_fields>
+		<field key="rconServerPort" type="text">
+			<default>"rconServerPort" : [\w\-\s]*</default>
+			<default_value>21026</default_value>
+			<var>"rconServerPort" :</var>
+			<filepath>storage/starbound_server.config</filepath>
+			<options>s</options>
+			<desc>RCON Server port</desc>
+		</field>
+	</custom_fields>
 </game_config>


### PR DESCRIPTION
Space Engineers previously attempted to install from the game ID ( https://steamdb.info/app/244850/ ) rather than the server ID ( https://steamdb.info/app/298740/ )

The same with Starbound. Game ID: https://steamdb.info/app/211820/ - Server ID: https://steamdb.info/app/533830/

Starbound also seems to support Windows, but we don't have a config for it yet.

This should close #66 