### PR TITLE
Change refresh time because...

### DIFF
--- a/modules/modulemanager/update_modules.php
+++ b/modules/modulemanager/update_modules.php
@@ -42,6 +42,6 @@ function exec_ogp_module()
 
 	print "<p>".get_lang_f('updating_finished')."</p>";
 	
-    $view->refresh("?m=modulemanager");
+    $view->refresh("?m=modulemanager",30);
 }
 ?>


### PR DESCRIPTION
...having default two seconds to read what happened during modules update (when clicking Update Modules link) is just ridiculous, 30 seconds may be too much but I think it is better to have time to read and/or copy the page output, than being instantly redirected.
Feel free to modify the value to whatever you think will be better, but for sure it needs more time.