### PR TITLE
Use http:// instead of https:// to fix the gametracker problem

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -95,8 +95,8 @@ function get_map_path($query_name,$mod,$map) {
 	$mod_gt = $query_name == "conanexiles" ? "conan" : $mod_gt;
 
 	$map_paths= array(
-		"https://image.gametracker.com/images/maps/160x120/$mod_gt/$map.jpg",
-		"https://image.gametracker.com/images/maps/160x120/$query_name/$map.jpg",
+		"http://image.gametracker.com/images/maps/160x120/$mod_gt/$map.jpg",
+		"http://image.gametracker.com/images/maps/160x120/$query_name/$map.jpg",
 		"protocol/lgsl/maps/$query_name/$mod/$map.jpg",
 		"protocol/lgsl/maps/$query_name/$mod/$map.gif",
 		"protocol/lgsl/maps/$query_name/$mod/$map.png",


### PR DESCRIPTION
Currently looks like Gametracker is going on under SSL Invailed problem so for now it would be fine to Use http:// instead of https:// to fix the problem.Its working fine with http:// currently, Maybe we can use the https:// when they fix the problem.