### PR TITLE
Panel Language Fix

### DIFF
--- a/home.php
+++ b/home.php
@@ -35,17 +35,17 @@ define("IMAGES", "images/");
 define("INCLUDES", "includes/");
 define("MODULES", "modules/");
 
-// Load languages.
-include_once("includes/lang.php");
-ogpLang();
-
 define("CONFIG_FILE","includes/config.inc.php");
 
 require_once CONFIG_FILE;
 // Connect to the database server and select database.
 $db = createDatabaseConnection($db_type, $db_host, $db_user, $db_pass, $db_name, $table_prefix);
 
+// Load languages.
+include_once("includes/lang.php");
+
 if (!$db instanceof OGPDatabase) {
+	ogpLang();
 	die(get_lang('no_db_connection'));
 }
 
@@ -56,6 +56,7 @@ if(hasValue($_SESSION['user_id'])){
 
 $settings = $db->getSettings();
 @$GLOBALS['panel_language'] = $settings['panel_language'];
+ogpLang();
 
 require_once("includes/view.php");
 $view = new OGPView();

--- a/index.php
+++ b/index.php
@@ -36,10 +36,6 @@ require_once("includes/functions.php");
 require_once("includes/helpers.php");
 require_once("includes/html_functions.php");
 
-// Load languages.
-include_once("includes/lang.php");
-ogpLang();
-
 // Start the session valid for opengamepanel_web only
 startSession();
 
@@ -62,7 +58,11 @@ require_once CONFIG_FILE;
 // Connect to the database server and select database.
 $db = createDatabaseConnection($db_type, $db_host, $db_user, $db_pass, $db_name, $table_prefix);
 
+// Load languages.
+include_once("includes/lang.php");
+
 if (!$db instanceof OGPDatabase) {
+	ogpLang();
 	die(get_lang('no_db_connection'));
 }
 
@@ -73,6 +73,7 @@ if(hasValue($_SESSION['user_id'])){
 
 $settings = $db->getSettings();
 @$GLOBALS['panel_language'] = $settings['panel_language'];
+ogpLang();
 
 require_once("includes/view.php");
 $view = new OGPView();


### PR DESCRIPTION
The last commit I made broke other languages and went unnoticed by me before commiting.

The reason for that is `ogpLang()` needs to be called after `$db->getSettings()`, but if there's no database connection (why stuff was slightly changed for), getSettings and any other method will cause a fatal error.

Fixed now, thanks @Zorrototo for noticing.

Closes #95 