### PR TITLE
Pagination Improvements

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -658,32 +658,51 @@ function hasValue($val, $zeroAllowed = false){
 	}
 }
 
-function paginationPages($pageResults, $currentPage, $perPage, $pageUri, $customClasses) {
-	$pagination = '';
+function paginationPages($pageResults, $currentPage, $perPage, $pageUri, $pagesShown, $classPrefix) {
+	$pagination = '<div id="pagination">';
 
 	if ($pageResults > $perPage) {
-		if ($currentPage > 1) {
-			$pagination .= '<a href="'.$pageUri . ($currentPage-1) .'" class="'.$customClasses['previousLink'].'">Previous</a> ';
-		}
 
 		$totalPages = ceil($pageResults/$perPage);
+		$pageStart = (($currentPage - $pagesShown) > 0) ? $currentPage - $pagesShown : 1;
+		$pageEnd = (($currentPage + $pagesShown) < $totalPages) ? $currentPage + $pagesShown : $totalPages;
+		
+		if ($pageStart > 1) {
+			$pagination .= '<span class="'.$classPrefix.'_paginationStart">
+				<a href="'.$pageUri . ($currentPage-1) .'" class="'.$classPrefix.'_previousPageLink">&laquo;</a>
+				<a href="'.$pageUri .'1" class="'.$classPrefix.'_firstPageLink">1</a>
+				<span class='.$classPrefix.'_divider">&hellip;</span>
+			</span>';
+		}
 
-		for ($i=1; $i<=$totalPages;++$i) {
+		$pagination .= '<span class="'.$classPrefix.'_paginationPages">';
+
+		for ($i=$pageStart; $i<=$pageEnd; ++$i) {
+		
 			if ($currentPage == $i) {
-				$pagination .= '<span class="'.$customClasses['currentPage'].'">'.$i.'</span>';
+				$pagination .= '<a href="'.$pageUri . $i .'" class="'.$classPrefix.'_currentPageLink">['.$i.']</a>';
 			} else {
-				$pagination .= '<a href="'.$pageUri . $i .'" class="'.$customClasses['pageLinks'].'">'.$i.'</a>';
+				$pagination .= '<a href="'.$pageUri . $i .'" class="'.$classPrefix.'_pageLinks">'.$i.'</a>';
 			}
-
-			$pagination .= ($i < $totalPages) ? ', ' : ' ';
+		
+				$pagination .= ($i < $pageEnd) ? ', ' : ' ';
 		}
 
-		if ($currentPage < $totalPages) {
-			$pagination .= '<a href="'.$pageUri . ($currentPage+1) .'" class="'.$customClasses['nextLink'].'">Next</a>';
+		$pagination .= '</span>';
+
+		if ($pageEnd < $totalPages) {
+			$pagination .= '<span class="'.$classPrefix.'_paginationEnd">
+				<span class='.$classPrefix.'_divider">&hellip;</span>
+				<a href="'.$pageUri . $totalPages .'" class="'.$classPrefix.'_lastPageLink">'.$totalPages.'</a>
+				<a href="'.$pageUri . ($currentPage+1) .'" class="'.$classPrefix.'_nextPageLink">&raquo;</a>
+			</span>';
 		}
+
 	}
 
+	$pagination .= '</div>';
 	return $pagination;
+
 }
 
 ?>

--- a/modules/administration/watch_logger.php
+++ b/modules/administration/watch_logger.php
@@ -121,13 +121,6 @@ function exec_ogp_module() {
 	$count_logs = $db->get_logger_count();
 
 	$uri = '?m=administration&p=watch_logger&limit='.$l.'&page=';
-	echo paginationPages($count_logs[0]['total'], $p, $l, $uri,
-		array(
-			'previousLink' => 'watchLogger_previousPageLink',
-			'pageLinks' => 'watchLogger_pageLinks',
-			'nextLink' => 'watchLogger_nextPageLink',
-			'currentPage' => 'watchLogger_currentPageLink',
-		)
-	);
+	echo paginationPages($count_logs[0]['total'], $p, $l, $uri, 3, 'watchLogger');
 }
 ?>

--- a/modules/dashboard/dashboard.php
+++ b/modules/dashboard/dashboard.php
@@ -118,18 +118,11 @@ function exec_ogp_module()
 			}
 
 			$uri = '?m=dashboard&p=dashboard&limit='.$limit_user.'&page=';
-			$OnlineServers .= paginationPages($count_homes[0]['total'], $page_user, $limit_user, $uri,
-				array(
-					'previousLink' => 'dashboardHomes_previousPageLink',
-					'pageLinks' => 'dashboardHomes_pageLinks',
-					'nextLink' => 'dashboardHomes_nextPageLink',
-					'currentPage' => 'dashboardHomes_currentPageLink',
-				)
-			);
+			$OnlineServers .= paginationPages($count_homes[0]['total'], $page_user, $limit_user, $uri, 3, 'dashboardHomes');
 	
 			$OnlineServers .= "<center>" . statistics . ":<br>$stats_servers_online/$stats_servers " . servers . "<br>" . 
-						  $refresh->getdiv($refresh->add("home.php?m=dashboard&p=query_ref&show=player_statistics&type=cleared&ip=" .
-						  $server_home['ip']."&port=".$server_home['port'])) . "</center>";
+				$refresh->getdiv($refresh->add("home.php?m=dashboard&p=query_ref&show=player_statistics&type=cleared&ip=" .
+				$server_home['ip']."&port=".$server_home['port'])) . "</center>";
 		}
 		else
 		{

--- a/modules/gamemanager/server_monitor.php
+++ b/modules/gamemanager/server_monitor.php
@@ -646,14 +646,7 @@ function exec_ogp_module() {
 
 
 	$uri = '?m=gamemanager&p=game_monitor&limit='.$home_limit.'&page=';
-	echo paginationPages($homes_count[0]['total'], $home_page, $home_limit, $uri,
-		array(
-			'previousLink' => 'serverMonitor_previousPageLink',
-			'pageLinks' => 'serverMonitor_pageLinks',
-			'nextLink' => 'serverMonitor_nextPageLink',
-			'currentPage' => 'serverMonitor_currentPageLink',
-		)
-	);
+	echo paginationPages($homes_count[0]['total'], $home_page, $home_limit, $uri, 3, 'serverMonitor');
 
 	echo "<div id=translation data-title='". upload_map_image .
 		 "' data-upload_button='". upload_image .

--- a/modules/user_admin/show_users.php
+++ b/modules/user_admin/show_users.php
@@ -103,14 +103,7 @@ function exec_ogp_module() {
 	$count_users = $db->get_user_count();
 	
 	$uri = '?m=user_admin&limit='.$limit_user.'&page=';
-	echo paginationPages($count_users[0]['total'], $page_user, $limit_user, $uri,
-		array(
-			'previousLink' => 'userManager_previousPageLink',
-			'pageLinks' => 'userManager_pageLinks',
-			'nextLink' => 'userManager_nextPageLink',
-			'currentPage' => 'userManager_currentPageLink',
-		)
-	);
-
+	echo paginationPages($count_users[0]['total'], $page_user, $limit_user, $uri, 3, 'userManager');
+	
 }
 ?>

--- a/modules/user_games/show_homes.php
+++ b/modules/user_games/show_homes.php
@@ -78,14 +78,7 @@ function exec_ogp_module()
 	$count_GameHomes = $db->get_GameHomes_count();
 
 	$uri = '?m=user_games&limit='.$limit_GameHomes.'&page=';
-	echo paginationPages($count_GameHomes[0]['total'], $page_GameHomes, $limit_GameHomes, $uri,
-		array(
-			'previousLink' => 'userGames_previousPageLink',
-			'pageLinks' => 'userGames_pageLinks',
-			'nextLink' => 'userGames_nextPageLink',
-			'currentPage' => 'userGames_currentPageLink',
-		)
-	);
+	echo paginationPages($count_GameHomes[0]['total'], $page_GameHomes, $limit_GameHomes, $uri, 3, 'userGames');
 
 	?>
 	<script type="text/javascript">


### PR DESCRIPTION
Implements the suggestion by @Obada8 made [here](http://www.opengamepanel.org/forum/viewthread.php?thread_id=5329#post_25974).

This will also make for cleaner output in the event there's several page links that need to be rendered since the maximum that can be shown is defined by `$pagesShown` in the `paginationPages` function.

I'm no longer passing an array to the paginationPages function but rather just a class prefix.

You can see in the attached image how page numbers are rendered now. There's a total of 32 pages - the first and last page number will always be visible. The current page number will always be in the middle. To show more page numbers, change the `$pagesShown` argument passed to paginationPages.

![Pagination Image](http://i.imgur.com/Etw0hcI.png)