### PR TITLE
Fix Install From Local Master Button

### DIFF
--- a/js/modules/gamemanager.js
+++ b/js/modules/gamemanager.js
@@ -155,4 +155,22 @@ $(document).ready(function(){
 			}
 		});
 	});
+
+	$('.masterserver_update').click(function(e) {
+		e.preventDefault();
+
+		var updatePage = (this.getAttribute('data-page') == 'rsync_install' ? 'rsync_install' : 'update');
+		var homeId = this.getAttribute('data-home-id');
+		var modId = this.getAttribute('data-mod-id');
+		var masterServerValue = this.getAttribute('data-masterserver-id');
+
+		var pageAction = '?m=gamemanager&p=' + updatePage + '&home_id=' + homeId + '&mod_id=' + modId + '&update=update';
+		var masterServer = (masterServerValue == null ? '' : '<input type="hidden" name="master_server_home_id" value="' + masterServerValue + '">');
+
+		var updateForm = $('<form action="' + pageAction + '" method="POST">' + masterServer + '</form>');
+
+		$('body').append(updateForm);
+		updateForm.submit();
+	});
+
 });

--- a/js/modules/gamemanager.js
+++ b/js/modules/gamemanager.js
@@ -155,22 +155,4 @@ $(document).ready(function(){
 			}
 		});
 	});
-
-	$('.masterserver_update').click(function(e) {
-		e.preventDefault();
-
-		var updatePage = (this.getAttribute('data-page') == 'rsync_install' ? 'rsync_install' : 'update');
-		var homeId = this.getAttribute('data-home-id');
-		var modId = this.getAttribute('data-mod-id');
-		var masterServerValue = this.getAttribute('data-masterserver-id');
-
-		var pageAction = '?m=gamemanager&p=' + updatePage + '&home_id=' + homeId + '&mod_id=' + modId + '&update=update';
-		var masterServer = (masterServerValue == null ? '' : '<input type="hidden" name="master_server_home_id" value="' + masterServerValue + '">');
-
-		var updateForm = $('<form action="' + pageAction + '" method="POST">' + masterServer + '</form>');
-
-		$('body').append(updateForm);
-		updateForm.submit();
-	});
-
 });

--- a/lang/English/modules/gamemanager.php
+++ b/lang/English/modules/gamemanager.php
@@ -192,4 +192,7 @@ define('auto_update_copy_me', "Copy");
 define('auto_update_copy_me_success', "Copied!");
 define('auto_update_copy_me_fail', "Failed to copy. Please manually copy the link.");
 define('get_steam_autoupdate_api_link', "Auto Update Link");
+define('update_attempt_from_nonmaster_server', "User %s attempted to update home_id %d from a non-master server. (Home ID: %d)");
+define('attempting_nonmaster_update', "You are attempting to update this server from a non-master server.")
+
 ?>

--- a/lang/English/modules/gamemanager.php
+++ b/lang/English/modules/gamemanager.php
@@ -194,5 +194,6 @@ define('auto_update_copy_me_fail', "Failed to copy. Please manually copy the lin
 define('get_steam_autoupdate_api_link', "Auto Update Link");
 define('update_attempt_from_nonmaster_server', "User %s attempted to update home_id %d from a non-master server. (Home ID: %d)");
 define('attempting_nonmaster_update', "You are attempting to update this server from a non-master server.")
+define('cannot_update_from_own_self', "Local Server Update may not run on a master server.");
 
 ?>

--- a/modules/gamemanager/rsync_install.php
+++ b/modules/gamemanager/rsync_install.php
@@ -205,11 +205,16 @@ function exec_ogp_module() {
 			$ms_home_id = $_REQUEST['master_server_home_id'];
 
 			if ($db->getMasterServer($home_info['remote_server_id'], $home_info['home_cfg_id']) == $ms_home_id) {
-				$ms_info = $db->getGameHome($ms_home_id);
-				print_success(get_lang_f("starting_copy_with_master_server_named",htmlentities($ms_info['home_name'])));
-				$rsync = $remote->masterServerUpdate( $home_id,$home_info['home_path'],$ms_home_id,$ms_info['home_path'],$exec_folder_path,$exec_path,$precmd,$postcmd );
+				if ($ms_home_id !== $home_id) {
+					$ms_info = $db->getGameHome($ms_home_id);
+					print_success(get_lang_f("starting_copy_with_master_server_named",htmlentities($ms_info['home_name'])));
+					$rsync = $remote->masterServerUpdate( $home_id,$home_info['home_path'],$ms_home_id,$ms_info['home_path'],$exec_folder_path,$exec_path,$precmd,$postcmd );
 
-				$master = "&amp;master=true";
+					$master = "&amp;master=true";
+				} else {
+					print_failure(get_lang('cannot_update_from_own_self'));
+					$view->refresh('?m=gamemanager&p=game_monitor', 2);
+				}
 			} else {
 				$db->logger(get_lang_f('update_attempt_from_nonmaster_server', $_SESSION['users_login'], $home_id, $ms_home_id));
 				print_failure(get_lang('attempting_nonmaster_update'));

--- a/modules/gamemanager/rsync_install.php
+++ b/modules/gamemanager/rsync_install.php
@@ -214,6 +214,8 @@ function exec_ogp_module() {
 				} else {
 					print_failure(get_lang('cannot_update_from_own_self'));
 					$view->refresh('?m=gamemanager&p=game_monitor', 2);
+					
+					return;
 				}
 			} else {
 				$db->logger(get_lang_f('update_attempt_from_nonmaster_server', $_SESSION['users_login'], $home_id, $ms_home_id));

--- a/modules/gamemanager/rsync_install.php
+++ b/modules/gamemanager/rsync_install.php
@@ -203,10 +203,20 @@ function exec_ogp_module() {
 		if( isset( $_REQUEST['master_server_home_id'] ) )
 		{
 			$ms_home_id = $_REQUEST['master_server_home_id'];
-			$ms_info = $db->getGameHome($ms_home_id);
-			print_success(get_lang_f("starting_copy_with_master_server_named",htmlentities($ms_info['home_name'])));
-			$rsync = $remote->masterServerUpdate( $home_id,$home_info['home_path'],$ms_home_id,$ms_info['home_path'],$exec_folder_path,$exec_path,$precmd,$postcmd );
-			$master = "&amp;master=true";
+
+			if ($db->getMasterServer($ms_home_id, $home_info['home_cfg_id']) !== false) {
+				$ms_info = $db->getGameHome($ms_home_id);
+				print_success(get_lang_f("starting_copy_with_master_server_named",htmlentities($ms_info['home_name'])));
+				$rsync = $remote->masterServerUpdate( $home_id,$home_info['home_path'],$ms_home_id,$ms_info['home_path'],$exec_folder_path,$exec_path,$precmd,$postcmd );
+
+				$master = "&amp;master=true";
+			} else {
+				$db->logger(get_lang_f('update_attempt_from_nonmaster_server', $_SESSION['users_login'], $home_id, $ms_home_id));
+				print_failure(get_lang('attempting_nonmaster_update'));
+				$view->refresh('?m=gamemanager&p=game_monitor', 2);
+
+				return;
+			}
 		}
 		else
 		{

--- a/modules/gamemanager/rsync_install.php
+++ b/modules/gamemanager/rsync_install.php
@@ -204,7 +204,7 @@ function exec_ogp_module() {
 		{
 			$ms_home_id = $_REQUEST['master_server_home_id'];
 
-			if ($db->getMasterServer($ms_home_id, $home_info['home_cfg_id']) !== false) {
+			if ($db->getMasterServer($home_info['remote_server_id'], $home_info['home_cfg_id']) == $ms_home_id) {
 				$ms_info = $db->getGameHome($ms_home_id);
 				print_success(get_lang_f("starting_copy_with_master_server_named",htmlentities($ms_info['home_name'])));
 				$rsync = $remote->masterServerUpdate( $home_id,$home_info['home_path'],$ms_home_id,$ms_info['home_path'],$exec_folder_path,$exec_path,$precmd,$postcmd );

--- a/modules/gamemanager/server_monitor.php
+++ b/modules/gamemanager/server_monitor.php
@@ -379,7 +379,7 @@ function exec_ogp_module() {
 					{						
 						if( $master_server_home_id != FALSE AND $master_server_home_id != $server_home['home_id']  )
 						{
-							$manager .= "<a class='monitorbutton' href='?m=gamemanager&amp;p=update&amp;home_id=".$server_home['home_id']."&amp;mod_id=".$server_home['mod_id']."&amp;update=update'>
+							$manager .= "<a class='monitorbutton masterserver_update' href='#' data-page='update' data-home-id='".$server_home['home_id']."' data-mod-id='".$server_home['mod_id']."' data-masterserver-id='".$master_server_home_id."'>
 								<img src='" . check_theme_image("images/master.png") . "' title='". update_from_local_master_server ."'>
 								<span>". update_from_local_master_server ."</span>
 							</a>";

--- a/modules/gamemanager/server_monitor.php
+++ b/modules/gamemanager/server_monitor.php
@@ -379,7 +379,7 @@ function exec_ogp_module() {
 					{						
 						if( $master_server_home_id != FALSE AND $master_server_home_id != $server_home['home_id']  )
 						{
-							$manager .= "<a class='monitorbutton masterserver_update' href='#' data-page='update' data-home-id='".$server_home['home_id']."' data-mod-id='".$server_home['mod_id']."' data-masterserver-id='".$master_server_home_id."'>
+							$manager .= "<a class='monitorbutton' href='?m=gamemanager&amp;p=update&amp;home_id=".$server_home['home_id']."&amp;mod_id=".$server_home['mod_id']."&amp;master_server_home_id=".$master_server_home_id."&amp;update=update'>
 								<img src='" . check_theme_image("images/master.png") . "' title='". update_from_local_master_server ."'>
 								<span>". update_from_local_master_server ."</span>
 							</a>";

--- a/modules/gamemanager/update_server.php
+++ b/modules/gamemanager/update_server.php
@@ -114,8 +114,18 @@ function exec_ogp_module() {
 			if( isset( $_REQUEST['master_server_home_id'] ) )
 			{
 				$ms_home_id = $_REQUEST['master_server_home_id'];
-				$ms_info = $db->getGameHome($ms_home_id);
-				$steam_out = $remote->masterServerUpdate( $home_id,$home_info['home_path'],$ms_home_id,$ms_info['home_path'],$exec_folder_path,$exec_path,$precmd,$postcmd );
+
+				if ($db->getMasterServer($ms_home_id, $home_info['home_cfg_id']) !== false) {
+					$ms_info = $db->getGameHome($ms_home_id);
+					$steam_out = $remote->masterServerUpdate( $home_id,$home_info['home_path'],$ms_home_id,$ms_info['home_path'],$exec_folder_path,$exec_path,$precmd,$postcmd );
+				} else {
+					$db->logger(get_lang_f('update_attempt_from_nonmaster_server', $_SESSION['users_login'], $home_id, $ms_home_id));
+					print_failure(get_lang('attempting_nonmaster_update'));
+					$view->refresh('?m=gamemanager&p=game_monitor', 2);
+
+					return;
+				}
+
 			}
 			else
 			{

--- a/modules/gamemanager/update_server.php
+++ b/modules/gamemanager/update_server.php
@@ -122,6 +122,8 @@ function exec_ogp_module() {
 					} else {
 						print_failure(get_lang('cannot_update_from_own_self'));
 						$view->refresh('?m=gamemanager&p=game_monitor', 2);
+						
+						return;
 					}
 				} else {
 					$db->logger(get_lang_f('update_attempt_from_nonmaster_server', $_SESSION['users_login'], $home_id, $ms_home_id));

--- a/modules/gamemanager/update_server.php
+++ b/modules/gamemanager/update_server.php
@@ -116,8 +116,13 @@ function exec_ogp_module() {
 				$ms_home_id = $_REQUEST['master_server_home_id'];
 				
 				if ($db->getMasterServer($home_info['remote_server_id'], $home_info['home_cfg_id']) == $ms_home_id) {
-					$ms_info = $db->getGameHome($ms_home_id);
-					$steam_out = $remote->masterServerUpdate( $home_id,$home_info['home_path'],$ms_home_id,$ms_info['home_path'],$exec_folder_path,$exec_path,$precmd,$postcmd );
+					if ($ms_home_id !== $home_id) {
+						$ms_info = $db->getGameHome($ms_home_id);
+						$steam_out = $remote->masterServerUpdate( $home_id,$home_info['home_path'],$ms_home_id,$ms_info['home_path'],$exec_folder_path,$exec_path,$precmd,$postcmd );
+					} else {
+						print_failure(get_lang('cannot_update_from_own_self'));
+						$view->refresh('?m=gamemanager&p=game_monitor', 2);
+					}
 				} else {
 					$db->logger(get_lang_f('update_attempt_from_nonmaster_server', $_SESSION['users_login'], $home_id, $ms_home_id));
 					print_failure(get_lang('attempting_nonmaster_update'));
@@ -125,7 +130,7 @@ function exec_ogp_module() {
 
 					return;
 				}
-
+				
 			}
 			else
 			{

--- a/modules/gamemanager/update_server.php
+++ b/modules/gamemanager/update_server.php
@@ -114,8 +114,8 @@ function exec_ogp_module() {
 			if( isset( $_REQUEST['master_server_home_id'] ) )
 			{
 				$ms_home_id = $_REQUEST['master_server_home_id'];
-
-				if ($db->getMasterServer($ms_home_id, $home_info['home_cfg_id']) !== false) {
+				
+				if ($db->getMasterServer($home_info['remote_server_id'], $home_info['home_cfg_id']) == $ms_home_id) {
 					$ms_info = $db->getGameHome($ms_home_id);
 					$steam_out = $remote->masterServerUpdate( $home_id,$home_info['home_path'],$ms_home_id,$ms_info['home_path'],$exec_folder_path,$exec_path,$precmd,$postcmd );
 				} else {


### PR DESCRIPTION
Fixes the install from local master server button, by initiating a request via JS.

Also fixes the possibility of users forging the value of master_server_home_id to copy files from other server homes. It will now check if the given value of master_server_home_id is a master server for the corresponding mod id or not.