### PR TITLE
Fix Core Assignment For Games Under Wine

### DIFF
--- a/modules/user_games/edit_home.php
+++ b/modules/user_games/edit_home.php
@@ -533,13 +533,11 @@ function exec_ogp_module()
 			}
 
 			// If we're on Windows, and some cores have been selected...
-			if(preg_match('/win/', $remote->what_os()) && $cpus !== 'NA')
-			{
+			if (preg_match('/cygwin/i', $remote->what_os()) && $cpus !== 'NA') {
 				$result = 0;
 				$cores = explode(',', $cpus);
 
-				foreach ($cores as $core)
-				{
+				foreach ($cores as $core) {
 					$coreNum = intval($core);
 					$result |= (1 << $coreNum);
 				}


### PR DESCRIPTION
The what_os() call includes 'wine' in the returned string, thus is was being caught by the preg_match and what was being stored was the Windows bitmask for the affinity.

Checking for Cygwin seems to be correct from looking over what's returned by what_os().

Fix for: http://www.opengamepanel.org/forum/viewthread.php?thread_id=5389 and working on Ubuntu/Windows 2012