### PR TITLE
Anonymous Login for Day of Infamy

### DIFF
--- a/modules/config_games/server_configs/doi.xml
+++ b/modules/config_games/server_configs/doi.xml
@@ -22,6 +22,7 @@
 		<mod key="doi">
 			<name>none</name>
 			<installer_name>462310</installer_name>
+			<installer_login>anonymous</installer_login>
 		</mod>
 	</mods>
 	<replace_texts>

--- a/modules/config_games/server_configs/doi_win.xml
+++ b/modules/config_games/server_configs/doi_win.xml
@@ -22,6 +22,7 @@
 		<mod key="doi">
 			<name>none</name>
 			<installer_name>462310</installer_name>
+			<installer_login>anonymous</installer_login>
 		</mod>
 	</mods>
 	<replace_texts>


### PR DESCRIPTION
http://www.opengamepanel.org/forum/viewthread.php?thread_id=5405

As Omano pointed out, lots of servers require aninymous login. I forgot to add this on initial commit.

As such, it'll use the Steam login info stored in the database to download the game, but to download the game you need to login as anonymous.