### PR TITLE
Update rcon.php

### DIFF
--- a/modules/gamemanager/rcon.php
+++ b/modules/gamemanager/rcon.php
@@ -127,7 +127,7 @@ if(isset($_POST['remote_send_rcon_command']))
 	if($response)
 	{
 		echo "<div class='bloc' ><h4>" . rcon_command_title . ": [" . htmlentities(implode(" | ", $_POST['command'])) . "] " .
-			 has_sent_to . " " . $home_info['home_name'] . "</h4><xmp style='overflow:scroll;' >" . 
+			 has_sent_to . " " . $home_info['home_name'] . "</h4><xmp style='overflow:auto;' >" . 
 			 $response . "</xmp></div>";
 	}
 }


### PR DESCRIPTION
The RCON output area has no height styling on the XMP tag, so it doesn't need scroll overflow as it'll never be limited in height for scrollbars to be usable in the vertical pane. Scrollbars will only ever be usable on the horizontal pane.