### PR TITLE
Adding search function.

### DIFF
--- a/includes/database.php
+++ b/includes/database.php
@@ -178,7 +178,7 @@ abstract class OGPDatabase {
 
     abstract public function getHomesFor($id_type,$assign_id);
     
-    abstract public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id,$search_field);
+    abstract public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id);
 
     abstract public function getHomeMods($home_id);
 

--- a/includes/database.php
+++ b/includes/database.php
@@ -63,7 +63,7 @@ abstract class OGPDatabase {
 
     abstract public function getUserList();
     
-    abstract public function getUserList_limit($page_user,$limit_user);
+    abstract public function getUserList_limit($page_user,$limit_user,$search_field);
 
     abstract public function getGroupList();
 
@@ -178,7 +178,7 @@ abstract class OGPDatabase {
 
     abstract public function getHomesFor($id_type,$assign_id);
     
-    abstract public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id);
+    abstract public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id,$search_field);
 
     abstract public function getHomeMods($home_id);
 
@@ -256,7 +256,7 @@ abstract class OGPDatabase {
 
     abstract public function getGameHomes();
     
-    abstract public function getGameHomes_limit($page_gameHomes,$limit_gameHomes);
+    abstract public function getGameHomes_limit($page_gameHomes,$limit_gameHomes,$search_field);
 
     /// \return true If username and password match.
     /// \return false If username and password does not match

--- a/includes/database.php
+++ b/includes/database.php
@@ -178,7 +178,7 @@ abstract class OGPDatabase {
 
     abstract public function getHomesFor($id_type,$assign_id);
     
-    abstract public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id);
+    abstract public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id,$search_field);
 
     abstract public function getHomeMods($home_id);
 

--- a/includes/database_mysql.php
+++ b/includes/database_mysql.php
@@ -256,29 +256,34 @@ class OGPDatabaseMySQL extends OGPDatabase
 		return $results;
 	}
 	
-	public function getUserList_limit($page_user,$limit_user) {
+	public function getUserList_limit($page_user,$limit_user,$search_field) {
 		
        $user_get_id = ($page_user - 1) * $limit_user;		
 	
 		if ( !$this->link ) return;
 		$query = sprintf("SELECT user_id,users_login,users_lang,
 			users_role,users_fname,users_lname,users_email,user_expires,users_parent
-			FROM %susers ORDER BY users_login ASC LIMIT $user_get_id,$limit_user",
+			FROM %susers 
+			".($search_field ? "WHERE `user_id` = '$search_field' OR `users_login` = '$search_field' OR `users_lang` = '$search_field'
+			OR `users_role` = '$search_field' OR `users_fname` = '$search_field' OR `users_lname` = '$search_field' OR `users_email` = '$search_field'
+			OR `user_expires` = '$search_field' OR `users_parent` = '$search_field' " : "" )." 
+			ORDER BY users_login ASC LIMIT $user_get_id,$limit_user",
 			$this->table_prefix);
-
 		++$this->queries_;
 		$result = mysql_query($query,$this->link);
-
 		$results = array();
-
 		while ( $row = mysql_fetch_assoc( $result ) )
 			array_push($results,$row);
-
 		return $results;
 	}
 	
-	public function get_user_count(){
-		return $this->resultQuery("SELECT COUNT(user_id) AS total FROM `".$this->table_prefix."users`;");
+	public function get_user_count($search_field){
+		return $this->resultQuery("SELECT COUNT(user_id) AS total FROM `".$this->table_prefix."users`
+		".($search_field ? "WHERE `user_id` = '$search_field' OR `users_login` = '$search_field' OR `users_lang` = '$search_field'
+			OR `users_role` = '$search_field' OR `users_fname` = '$search_field' OR `users_lname` = '$search_field' OR `users_email` = '$search_field'
+			OR `user_expires` = '$search_field' OR `users_parent` = '$search_field' " : "" )."
+		
+		;");
 	}
 
 	public function getGroupList() {
@@ -1394,23 +1399,44 @@ class OGPDatabaseMySQL extends OGPDatabase
 		}
 	}
 
-	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id){
+	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id,$search_field){
 		if ( $id_type == "admin" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'server_homes`' . ($home_cfg_id ?' WHERE home_cfg_id = '.$home_cfg_id : ''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'server_homes` 
+			NATURAL JOIN `'.$this->table_prefix.'user_homes` NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
+			NATURAL JOIN `'.$this->table_prefix.'home_ip_ports`'  
+			
+			.($home_cfg_id ?" WHERE home_cfg_id = '$home_cfg_id'
+			".($search_field ?" OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+								OR home_name = '$search_field' 
+								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR user_id = '$search_field'
+								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR port = '$search_field'
+								" : '') 
+			
+			: '
+			
+			'.($search_field ?" WHERE home_cfg_id = '$home_cfg_id' OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+								OR home_name = '$search_field' 
+								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR user_id = '$search_field'
+								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR port = '$search_field'
+								" : '').''));
 		}
 		else if ( $id_type == "user_and_group" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_homes` WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_homes` WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' '.($search_field ? ' AND home_cfg_id = '.$search_field.'' : '').' )':''.($search_field ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$search_field.')' : '').''));
 		}
 		else if ( $id_type == "subuser" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_group_homes` WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_group_homes` WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' '.($search_field ? ' AND home_cfg_id = '.$search_field.'' : '').' )': ''.($search_field ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$search_field.')' : '').''));
 		}		
 		
 	}
 	
-	public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id){
+	public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id,$search_field){
 	$gethome_page_forlimit = ($home_page - 1) * $home_limit;	
 		if ( $id_type == "admin" )
 		{
@@ -1449,7 +1475,18 @@ class OGPDatabaseMySQL extends OGPDatabase
 							FROM `%1$shome_ip_ports`
 							WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 						)
-						'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
+						'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.'
+						
+						'.($search_field ?' OR %1$sserver_homes.home_id = \''.$search_field.'\' OR %1$sserver_homes.user_id_main = \''.$search_field.'\'
+						 OR %1$sserver_homes.home_path = \''.$search_field.'\' OR %1$sserver_homes.home_name = \''.$search_field.'\'
+						 OR user_id_main IN (SELECT `user_id` FROM `'.$this->table_prefix.'users` WHERE users_login = \''.$search_field.'\')
+						 OR %1$shome_ip_ports.port = \''.$search_field.'\'' : '')
+						: '
+						'.($search_field ?' OR %1$sserver_homes.home_id = \''.$search_field.'\' OR %1$sserver_homes.user_id_main = \''.$search_field.'\'
+						 OR %1$sserver_homes.home_path = \''.$search_field.'\' OR %1$sserver_homes.home_name = \''.$search_field.'\'
+						 OR user_id_main IN (SELECT `user_id` FROM `'.$this->table_prefix.'users` WHERE users_login = \''.$search_field.'\')
+						 OR %1$shome_ip_ports.port = \''.$search_field.'\'' : '').'').'
+						 
 						OR %1$shome_ip_ports.force_mod_id IS NULL LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 						
 			$template2 = 'SELECT user_expiration_date, home_id FROM %1$suser_homes WHERE user_id = %2$d;';
@@ -1465,7 +1502,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 				%1$suser_homes.user_expiration_date, %1$sremote_servers.*, %1$sconfig_homes.*
 				FROM %1$sremote_servers NATURAL JOIN %1$suser_homes
 				NATURAL JOIN %1$sserver_homes NATURAL JOIN %1$sconfig_homes
-				WHERE %1$suser_homes.user_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
+				WHERE %1$suser_homes.user_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 		}
 		else if ( $id_type == "group" )
 		{
@@ -1473,7 +1510,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 				%1$suser_group_homes.user_group_expiration_date, %1$sremote_servers.*, %1$sconfig_homes.*
 				FROM %1$sremote_servers NATURAL JOIN %1$suser_group_homes
 				NATURAL JOIN %1$sserver_homes NATURAL JOIN %1$sconfig_homes
-				WHERE %1$suser_group_homes.group_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
+				WHERE %1$suser_group_homes.group_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 		}
 		else if ( $id_type == "user_and_group" )
 		{
@@ -1515,7 +1552,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
+							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL
 						)
 						UNION
@@ -1562,7 +1599,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
+							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL 
 						) 
 						LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
@@ -2524,16 +2561,28 @@ class OGPDatabaseMySQL extends OGPDatabase
 		return $this->listQuery($query);
 	}
 	
-	public function getGameHomes_limit($page_gameHomes,$limit_gameHomes){
+	public function getGameHomes_limit($page_gameHomes,$limit_gameHomes,$search_field){
 		$game_home_id = ($page_gameHomes - 1) * $limit_gameHomes;
 		$query = sprintf('SELECT %1$sserver_homes.*, %1$sremote_servers.*, %1$sconfig_homes.*
-			FROM `%1$sserver_homes` NATURAL JOIN `%1$sconfig_homes` NATURAL JOIN `%1$sremote_servers` ORDER BY home_id ASC LIMIT '.$game_home_id.','.$limit_gameHomes.'; ',
+			FROM `%1$sserver_homes` NATURAL JOIN `%1$sconfig_homes` NATURAL JOIN `%1$sremote_servers` 
+			'.($search_field ? "WHERE home_id = '$search_field' OR remote_server_id = '$search_field'
+			OR user_id_main = '$search_field' OR home_path = '$search_field' OR home_cfg_id = '$search_field'
+			OR home_name = '$search_field' OR agent_ip = '$search_field' OR remote_server_name = '$search_field'
+			OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+			" : "").'
+			ORDER BY home_id ASC LIMIT '.$game_home_id.','.$limit_gameHomes.'; ',
 			$this->table_prefix);
 		return $this->listQuery($query);
 	}
 	
-   public function get_GameHomes_count(){
-      return $this->resultQuery("SELECT COUNT(home_id) AS total FROM `".$this->table_prefix."server_homes`;");
+   public function get_GameHomes_count($search_field){
+      return $this->resultQuery("SELECT COUNT(home_id) AS total FROM `".$this->table_prefix."server_homes` NATURAL JOIN `".$this->table_prefix."remote_servers`
+	  ".($search_field ? "WHERE home_id = '$search_field' OR remote_server_id = '$search_field'
+			OR user_id_main = '$search_field' OR home_path = '$search_field' OR home_cfg_id = '$search_field'
+			OR home_name = '$search_field' OR agent_ip = '$search_field' OR remote_server_name = '$search_field'
+			OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+			" : "")."
+	  ;");
    }
 	
 	public function changeLastParam($home_id,$json) {
@@ -2784,13 +2833,24 @@ class OGPDatabaseMySQL extends OGPDatabase
 		$this->query("INSERT INTO OGP_DB_PREFIXlogger (date, user_id, ip, message) VALUE (FROM_UNIXTIME(UNIX_TIMESTAMP(), '%d-%m-%Y %H:%i:%s'), $user_id, '$client_ip', '$message');");
 	}
 
-	public function get_logger_count(){
-		return $this->resultQuery("SELECT COUNT(log_id) AS total FROM `".$this->table_prefix."logger`;");
+	public function get_logger_count($search_field){
+		return $this->resultQuery("SELECT COUNT(log_id) AS total FROM `".$this->table_prefix."logger` 
+		".($search_field ? " WHERE log_id = '$search_field' OR user_id = '$search_field' 
+		 OR ip = '$search_field' OR message = '$search_field' OR user_id
+		 IN 
+		 (SELECT user_id FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')" : "")."
+		;");
 	}
 	
-	public function read_logger($page,$limit){
+	public function read_logger($page,$limit,$search_field){
 		$log_id = ($page - 1) * $limit;
-		return $this->resultQuery("SELECT * FROM `".$this->table_prefix."logger` ORDER BY log_id DESC LIMIT $log_id,$limit;");
+		return $this->resultQuery("SELECT * FROM `".$this->table_prefix."logger` 
+		".($search_field ? " WHERE log_id = '$search_field' OR date = '$search_field'
+		 OR user_id = '$search_field' OR ip = '$search_field' OR message = '$search_field' OR user_id 
+		 IN 
+		 (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')" : "")." 
+		ORDER BY log_id DESC LIMIT $log_id,$limit;
+		");
 	}
 	
 	public function del_logger_log($log_id){

--- a/includes/database_mysql.php
+++ b/includes/database_mysql.php
@@ -1399,44 +1399,23 @@ class OGPDatabaseMySQL extends OGPDatabase
 		}
 	}
 
-	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id,$search_field){
+	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id){
 		if ( $id_type == "admin" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'server_homes` 
-			NATURAL JOIN `'.$this->table_prefix.'user_homes` NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
-			NATURAL JOIN `'.$this->table_prefix.'home_ip_ports`'  
-			
-			.($home_cfg_id ?" WHERE home_cfg_id = '$home_cfg_id'
-			".($search_field ?" OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
-								OR home_name = '$search_field' 
-								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
-								OR user_id = '$search_field'
-								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
-								OR port = '$search_field'
-								" : '') 
-			
-			: '
-			
-			'.($search_field ?" WHERE home_cfg_id = '$home_cfg_id' OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
-								OR home_name = '$search_field' 
-								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
-								OR user_id = '$search_field'
-								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
-								OR port = '$search_field'
-								" : '').''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'server_homes`' . ($home_cfg_id ?' WHERE home_cfg_id = '.$home_cfg_id : ''));
 		}
 		else if ( $id_type == "user_and_group" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_homes` WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' '.($search_field ? ' AND home_cfg_id = '.$search_field.'' : '').' )':''.($search_field ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$search_field.')' : '').''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_homes` WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
 		}
 		else if ( $id_type == "subuser" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_group_homes` WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' '.($search_field ? ' AND home_cfg_id = '.$search_field.'' : '').' )': ''.($search_field ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$search_field.')' : '').''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_group_homes` WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
 		}		
 		
 	}
 	
-	public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id,$search_field){
+	public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id){
 	$gethome_page_forlimit = ($home_page - 1) * $home_limit;	
 		if ( $id_type == "admin" )
 		{
@@ -1475,18 +1454,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 							FROM `%1$shome_ip_ports`
 							WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 						)
-						'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.'
-						
-						'.($search_field ?' OR %1$sserver_homes.home_id = \''.$search_field.'\' OR %1$sserver_homes.user_id_main = \''.$search_field.'\'
-						 OR %1$sserver_homes.home_path = \''.$search_field.'\' OR %1$sserver_homes.home_name = \''.$search_field.'\'
-						 OR user_id_main IN (SELECT `user_id` FROM `'.$this->table_prefix.'users` WHERE users_login = \''.$search_field.'\')
-						 OR %1$shome_ip_ports.port = \''.$search_field.'\'' : '')
-						: '
-						'.($search_field ?' OR %1$sserver_homes.home_id = \''.$search_field.'\' OR %1$sserver_homes.user_id_main = \''.$search_field.'\'
-						 OR %1$sserver_homes.home_path = \''.$search_field.'\' OR %1$sserver_homes.home_name = \''.$search_field.'\'
-						 OR user_id_main IN (SELECT `user_id` FROM `'.$this->table_prefix.'users` WHERE users_login = \''.$search_field.'\')
-						 OR %1$shome_ip_ports.port = \''.$search_field.'\'' : '').'').'
-						 
+						'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
 						OR %1$shome_ip_ports.force_mod_id IS NULL LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 						
 			$template2 = 'SELECT user_expiration_date, home_id FROM %1$suser_homes WHERE user_id = %2$d;';
@@ -1502,7 +1470,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 				%1$suser_homes.user_expiration_date, %1$sremote_servers.*, %1$sconfig_homes.*
 				FROM %1$sremote_servers NATURAL JOIN %1$suser_homes
 				NATURAL JOIN %1$sserver_homes NATURAL JOIN %1$sconfig_homes
-				WHERE %1$suser_homes.user_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
+				WHERE %1$suser_homes.user_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 		}
 		else if ( $id_type == "group" )
 		{
@@ -1510,7 +1478,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 				%1$suser_group_homes.user_group_expiration_date, %1$sremote_servers.*, %1$sconfig_homes.*
 				FROM %1$sremote_servers NATURAL JOIN %1$suser_group_homes
 				NATURAL JOIN %1$sserver_homes NATURAL JOIN %1$sconfig_homes
-				WHERE %1$suser_group_homes.group_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
+				WHERE %1$suser_group_homes.group_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 		}
 		else if ( $id_type == "user_and_group" )
 		{
@@ -1552,7 +1520,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').'
+							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL
 						)
 						UNION
@@ -1599,7 +1567,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').'
+							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL 
 						) 
 						LIMIT '.$gethome_page_forlimit.','.$home_limit.';';

--- a/includes/database_mysql.php
+++ b/includes/database_mysql.php
@@ -1402,7 +1402,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id,$search_field){
 		if ( $id_type == "admin" )
 		{
-			return $this->resultQuery('SELECT COUNT(distinct(home_id)) AS total FROM `'.$this->table_prefix.'server_homes`
+			return $this->resultQuery('SELECT COUNT('.($search_field ?'distinct':'').' home_id) AS total FROM `'.$this->table_prefix.'server_homes`
 			'.($search_field ? '
 			NATURAL JOIN `'.$this->table_prefix.'user_homes`
 			NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
@@ -1415,24 +1415,72 @@ class OGPDatabaseMySQL extends OGPDatabase
  								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
  								OR user_id = '$search_field'
  								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
- 								OR port = '$search_field'
+ 								OR agent_ip = '$search_field' OR port = '$search_field'
  								" : '')." ": '
  			'.($search_field ?" WHERE home_cfg_id = '$home_cfg_id' OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
  								OR home_name = '$search_field' 
  								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
  								OR user_id = '$search_field'
 								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
-								OR port = '$search_field'
+								OR agent_ip = '$search_field' OR port = '$search_field'
 								" : '').'
 								'));
 		}
 		else if ( $id_type == "user_and_group" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_homes` WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
+			return $this->resultQuery('SELECT COUNT('.($search_field ?'distinct':'').' home_id) AS total FROM `'.$this->table_prefix.'user_homes`
+			'.($search_field ? '
+			NATURAL JOIN `'.$this->table_prefix.'server_homes`
+			NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
+ 			NATURAL JOIN `'.$this->table_prefix.'home_ip_ports`
+			' : '').'
+			WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id`
+			IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.'
+			'.($search_field ?" AND home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+ 								OR home_name = '$search_field' 
+ 								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR user_id = '$search_field'
+ 								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR agent_ip = '$search_field' OR port = '$search_field'
+ 								" : '').')'
+								: 
+								'
+				 			'.($search_field ?" AND home_cfg_id = '$home_cfg_id' OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+ 								OR home_name = '$search_field' 
+ 								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR user_id = '$search_field'
+								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR agent_ip = '$search_field' OR port = '$search_field'
+								" : '').'				
+								' 
+								));
+		
+		
 		}
 		else if ( $id_type == "subuser" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_group_homes` WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
+			return $this->resultQuery('SELECT COUNT('.($search_field ?'distinct':'').' home_id) AS total FROM `'.$this->table_prefix.'user_group_homes`
+			'.($search_field ? '
+			NATURAL JOIN `'.$this->table_prefix.'user_homes`
+			NATURAL JOIN `'.$this->table_prefix.'server_homes`
+			NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
+ 			NATURAL JOIN `'.$this->table_prefix.'home_ip_ports`
+			' : '').'			
+			WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )
+			
+			' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.'
+			'.($search_field ?" AND home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+ 								OR home_name = '$search_field' 
+ 								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR agent_ip = '$search_field' OR port = '$search_field'
+ 								" : '').')'
+			:'
+			'.($search_field ?" AND home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+ 								OR home_name = '$search_field' 
+ 								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR agent_ip = '$search_field' OR port = '$search_field'
+ 								" : '').'
+			'));
 		}		
 		
 	}
@@ -1441,7 +1489,8 @@ class OGPDatabaseMySQL extends OGPDatabase
 	$gethome_page_forlimit = ($home_page - 1) * $home_limit;	
 		if ( $id_type == "admin" )
 		{
-			$template = 'SELECT	%1$sserver_homes.*, 
+			$template = 'SELECT '.($search_field ?'distinct':'').' 
+								%1$sserver_homes.*, 
 								%1$sremote_servers.*, 
 								%1$sconfig_homes.*, 
 								%1$shome_ip_ports.port,
@@ -1462,7 +1511,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								%1$sconfig_mods.def_postcmd,
 								%1$sconfig_mods.mod_cfg_id
 						FROM %1$sserver_homes
-						'.($search_field ?'NATURAL JOIN `%1$suser_homes`':'').'
+						'.($search_field ?'NATURAL JOIN `%1$suser_homes` ':'').'
 						NATURAL JOIN %1$sremote_servers
 						NATURAL JOIN %1$sconfig_homes
 						LEFT JOIN %1$sgame_mods 
@@ -1486,7 +1535,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 						OR user_id = \''.$search_field.'\'
 						OR user_id IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
 						OR home_name = \''.$search_field.'\'
-						OR port = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
 						' : '').' ' : '
 						'.($search_field ?'
 						AND %1$sserver_homes.home_id = \''.$search_field.'\'
@@ -1495,7 +1544,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 						OR user_id = \''.$search_field.'\'
 						OR user_id IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
 						OR home_name = \''.$search_field.'\'
-						OR port = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
 						' : '').'
 						').' OR %1$shome_ip_ports.force_mod_id IS NULL LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 						
@@ -1524,7 +1573,8 @@ class OGPDatabaseMySQL extends OGPDatabase
 		}
 		else if ( $id_type == "user_and_group" )
 		{
-			$template = 'SELECT	%1$suser_homes.*, 
+			$template = 'SELECT	'.($search_field ?'distinct':'').'
+								%1$suser_homes.*, 
 								%1$sserver_homes.*, 
 								%1$sremote_servers.*, 
 								%1$sconfig_homes.*, 
@@ -1562,11 +1612,32 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
+						'.($home_cfg_id ? '
+						AND %1$sserver_homes.home_cfg_id = \''.$home_cfg_id.'\'
+						'.($search_field ?'
+						AND %1$sserver_homes.home_id = \''.$search_field.'\'
+						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
+						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR user_id = \''.$search_field.'\'
+						OR user_id IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR home_name = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
+						' : '').' ' : '
+						'.($search_field ?'
+						AND %1$sserver_homes.home_id = \''.$search_field.'\'
+						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
+						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR user_id = \''.$search_field.'\'
+						OR user_id IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR home_name = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
+						' : '').'
+						').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL
 						)
 						UNION
-						SELECT	%1$suser_group_homes.*,
+						SELECT	'.($search_field ?'distinct':'').'
+								%1$suser_group_homes.*,
 								%1$sserver_homes.*, 
 								%1$sremote_servers.*, 
 								%1$sconfig_homes.*, 
@@ -1609,7 +1680,23 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
+						'.($home_cfg_id ? '
+						AND %1$sserver_homes.home_cfg_id = \''.$home_cfg_id.'\'
+						'.($search_field ?'
+						AND %1$sserver_homes.home_id = \''.$search_field.'\'
+						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
+						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR home_name = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
+						' : '').' ' : '
+						'.($search_field ?'
+						AND %1$sserver_homes.home_id = \''.$search_field.'\'
+						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
+						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR home_name = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
+						' : '').'
+						').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL 
 						) 
 						LIMIT '.$gethome_page_forlimit.','.$home_limit.';';

--- a/includes/database_mysql.php
+++ b/includes/database_mysql.php
@@ -1399,10 +1399,32 @@ class OGPDatabaseMySQL extends OGPDatabase
 		}
 	}
 
-	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id){
+	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id,$search_field){
 		if ( $id_type == "admin" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'server_homes`' . ($home_cfg_id ?' WHERE home_cfg_id = '.$home_cfg_id : ''));
+			return $this->resultQuery('SELECT COUNT(distinct(home_id)) AS total FROM `'.$this->table_prefix.'server_homes`
+			'.($search_field ? '
+			NATURAL JOIN `'.$this->table_prefix.'user_homes`
+			NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
+ 			NATURAL JOIN `'.$this->table_prefix.'home_ip_ports`
+			' : '').'
+			'
+ 			.($home_cfg_id ?" WHERE home_cfg_id = '$home_cfg_id'
+ 			".($search_field ?" AND home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+ 								OR home_name = '$search_field' 
+ 								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR user_id = '$search_field'
+ 								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR port = '$search_field'
+ 								" : '')." ": '
+ 			'.($search_field ?" WHERE home_cfg_id = '$home_cfg_id' OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+ 								OR home_name = '$search_field' 
+ 								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR user_id = '$search_field'
+								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR port = '$search_field'
+								" : '').'
+								'));
 		}
 		else if ( $id_type == "user_and_group" )
 		{
@@ -1415,7 +1437,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 		
 	}
 	
-	public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id){
+	public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id,$search_field){
 	$gethome_page_forlimit = ($home_page - 1) * $home_limit;	
 		if ( $id_type == "admin" )
 		{
@@ -1440,6 +1462,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								%1$sconfig_mods.def_postcmd,
 								%1$sconfig_mods.mod_cfg_id
 						FROM %1$sserver_homes
+						'.($search_field ?'NATURAL JOIN `%1$suser_homes`':'').'
 						NATURAL JOIN %1$sremote_servers
 						NATURAL JOIN %1$sconfig_homes
 						LEFT JOIN %1$sgame_mods 
@@ -1454,8 +1477,27 @@ class OGPDatabaseMySQL extends OGPDatabase
 							FROM `%1$shome_ip_ports`
 							WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 						)
-						'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
-						OR %1$shome_ip_ports.force_mod_id IS NULL LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
+						'.($home_cfg_id ? '
+						AND %1$sserver_homes.home_cfg_id = \''.$home_cfg_id.'\'
+						'.($search_field ?'
+						AND %1$sserver_homes.home_id = \''.$search_field.'\'
+						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
+						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR user_id = \''.$search_field.'\'
+						OR user_id IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR home_name = \''.$search_field.'\'
+						OR port = \''.$search_field.'\'
+						' : '').' ' : '
+						'.($search_field ?'
+						AND %1$sserver_homes.home_id = \''.$search_field.'\'
+						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
+						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR user_id = \''.$search_field.'\'
+						OR user_id IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR home_name = \''.$search_field.'\'
+						OR port = \''.$search_field.'\'
+						' : '').'
+						').' OR %1$shome_ip_ports.force_mod_id IS NULL LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 						
 			$template2 = 'SELECT user_expiration_date, home_id FROM %1$suser_homes WHERE user_id = %2$d;';
 			$template3 = 'SELECT user_group_expiration_date, home_id FROM %1$suser_group_homes WHERE group_id IN(

--- a/includes/database_mysqli.php
+++ b/includes/database_mysqli.php
@@ -253,29 +253,33 @@ class OGPDatabaseMySQL extends OGPDatabase
 		return $results;
 	}
 	
-	public function getUserList_limit($page_user,$limit_user) {
+	public function getUserList_limit($page_user,$limit_user,$search_field) {
 		
        $user_get_id = ($page_user - 1) * $limit_user;		
 	
 		if ( !$this->link ) return;
 		$query = sprintf("SELECT user_id,users_login,users_lang,
 			users_role,users_fname,users_lname,users_email,user_expires,users_parent
-			FROM %susers ORDER BY users_login ASC LIMIT $user_get_id,$limit_user",
+			FROM %susers 
+			".($search_field ? "WHERE `user_id` = '$search_field' OR `users_login` = '$search_field' OR `users_lang` = '$search_field'
+			OR `users_role` = '$search_field' OR `users_fname` = '$search_field' OR `users_lname` = '$search_field' OR `users_email` = '$search_field'
+			OR `user_expires` = '$search_field' OR `users_parent` = '$search_field' " : "" )."
+			ORDER BY users_login ASC LIMIT $user_get_id,$limit_user",
 			$this->table_prefix);
-
 		++$this->queries_;
 		$result = mysqli_query($this->link,$query);
-
 		$results = array();
-
 		while ( $row = mysqli_fetch_assoc( $result ) )
 			array_push($results,$row);
-
 		return $results;
 	}
 	
-	public function get_user_count(){
-		return $this->resultQuery("SELECT COUNT(user_id) AS total FROM `".$this->table_prefix."users`;");
+	public function get_user_count($search_field){
+		return $this->resultQuery("SELECT COUNT(user_id) AS total FROM `".$this->table_prefix."users` 
+		".($search_field ? "WHERE `user_id` = '$search_field' OR `users_login` = '$search_field' OR `users_lang` = '$search_field'
+			OR `users_role` = '$search_field' OR `users_fname` = '$search_field' OR `users_lname` = '$search_field' OR `users_email` = '$search_field'
+			OR `user_expires` = '$search_field' OR `users_parent` = '$search_field' " : "" )."
+		;");
 	}
 
 	public function getGroupList() {
@@ -1391,23 +1395,44 @@ class OGPDatabaseMySQL extends OGPDatabase
 		}
 	}
 	
-	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id){
+	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id,$search_field){
 		if ( $id_type == "admin" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'server_homes`' . ($home_cfg_id ?' WHERE home_cfg_id = '.$home_cfg_id : ''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'server_homes` 
+			NATURAL JOIN `'.$this->table_prefix.'user_homes` NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
+			NATURAL JOIN `'.$this->table_prefix.'home_ip_ports`'  
+			
+			.($home_cfg_id ?" WHERE home_cfg_id = '$home_cfg_id'
+			".($search_field ?" OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+								OR home_name = '$search_field' 
+								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR user_id = '$search_field'
+								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR port = '$search_field'
+								" : '') 
+			
+			: '
+			
+			'.($search_field ?" WHERE home_cfg_id = '$home_cfg_id' OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+								OR home_name = '$search_field' 
+								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR user_id = '$search_field'
+								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR port = '$search_field'
+								" : '').''));
 		}
 		else if ( $id_type == "user_and_group" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_homes` WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_homes` WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' '.($search_field ? ' AND home_cfg_id = '.$search_field.'' : '').' )':''.($search_field ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$search_field.')' : '').''));
 		}
 		else if ( $id_type == "subuser" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_group_homes` WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_group_homes` WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' '.($search_field ? ' AND home_cfg_id = '.$search_field.'' : '').' )': ''.($search_field ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$search_field.')' : '').''));
 		}		
 		
 	}
 	
-	public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id){
+	public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id,$search_field){
 	$gethome_page_forlimit = ($home_page - 1) * $home_limit;	
 		if ( $id_type == "admin" )
 		{
@@ -1446,7 +1471,18 @@ class OGPDatabaseMySQL extends OGPDatabase
 							FROM `%1$shome_ip_ports`
 							WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 						)
-						'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
+						'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.'
+						
+						'.($search_field ?' OR %1$sserver_homes.home_id = \''.$search_field.'\' OR %1$sserver_homes.user_id_main = \''.$search_field.'\'
+						 OR %1$sserver_homes.home_path = \''.$search_field.'\' OR %1$sserver_homes.home_name = \''.$search_field.'\'
+						 OR user_id_main IN (SELECT `user_id` FROM `'.$this->table_prefix.'users` WHERE users_login = \''.$search_field.'\')
+						 OR %1$shome_ip_ports.port = \''.$search_field.'\'' : '')
+						: '
+						'.($search_field ?' OR %1$sserver_homes.home_id = \''.$search_field.'\' OR %1$sserver_homes.user_id_main = \''.$search_field.'\'
+						 OR %1$sserver_homes.home_path = \''.$search_field.'\' OR %1$sserver_homes.home_name = \''.$search_field.'\'
+						 OR user_id_main IN (SELECT `user_id` FROM `'.$this->table_prefix.'users` WHERE users_login = \''.$search_field.'\')
+						 OR %1$shome_ip_ports.port = \''.$search_field.'\'' : '').'').'
+						 
 						OR %1$shome_ip_ports.force_mod_id IS NULL LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 						
 			$template2 = 'SELECT user_expiration_date, home_id FROM %1$suser_homes WHERE user_id = %2$d;';
@@ -1462,7 +1498,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 				%1$suser_homes.user_expiration_date, %1$sremote_servers.*, %1$sconfig_homes.*
 				FROM %1$sremote_servers NATURAL JOIN %1$suser_homes
 				NATURAL JOIN %1$sserver_homes NATURAL JOIN %1$sconfig_homes
-				WHERE %1$suser_homes.user_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
+				WHERE %1$suser_homes.user_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 		}
 		else if ( $id_type == "group" )
 		{
@@ -1470,7 +1506,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 				%1$suser_group_homes.user_group_expiration_date, %1$sremote_servers.*, %1$sconfig_homes.*
 				FROM %1$sremote_servers NATURAL JOIN %1$suser_group_homes
 				NATURAL JOIN %1$sserver_homes NATURAL JOIN %1$sconfig_homes
-				WHERE %1$suser_group_homes.group_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
+				WHERE %1$suser_group_homes.group_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 		}
 		else if ( $id_type == "user_and_group" )
 		{
@@ -1512,7 +1548,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
+							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL
 						)
 						UNION
@@ -1559,7 +1595,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
+							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL
 						) 
 						LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
@@ -2531,16 +2567,28 @@ class OGPDatabaseMySQL extends OGPDatabase
 		return $this->listQuery($query);
 	}
 	
-	public function getGameHomes_limit($page_gameHomes,$limit_gameHomes){
+	public function getGameHomes_limit($page_gameHomes,$limit_gameHomes,$search_field){
 		$game_home_id = ($page_gameHomes - 1) * $limit_gameHomes;
 		$query = sprintf('SELECT %1$sserver_homes.*, %1$sremote_servers.*, %1$sconfig_homes.*
-			FROM `%1$sserver_homes` NATURAL JOIN `%1$sconfig_homes` NATURAL JOIN `%1$sremote_servers` ORDER BY home_id ASC LIMIT '.$game_home_id.','.$limit_gameHomes.'; ',
+			FROM `%1$sserver_homes` NATURAL JOIN `%1$sconfig_homes` NATURAL JOIN `%1$sremote_servers` 
+			'.($search_field ? "WHERE home_id = '$search_field' OR remote_server_id = '$search_field'
+			OR user_id_main = '$search_field' OR home_path = '$search_field' OR home_cfg_id = '$search_field'
+			OR home_name = '$search_field' OR agent_ip = '$search_field' OR remote_server_name = '$search_field'
+			OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+			" : "").'
+			ORDER BY home_id ASC LIMIT '.$game_home_id.','.$limit_gameHomes.'; ',
 			$this->table_prefix);
 		return $this->listQuery($query);
 	}
 	
-   public function get_GameHomes_count(){
-      return $this->resultQuery("SELECT COUNT(home_id) AS total FROM `".$this->table_prefix."server_homes`;");
+   public function get_GameHomes_count($search_field){
+      return $this->resultQuery("SELECT COUNT(home_id) AS total FROM `".$this->table_prefix."server_homes` NATURAL JOIN `".$this->table_prefix."remote_servers`
+	  ".($search_field ? "WHERE home_id = '$search_field' OR remote_server_id = '$search_field'
+			OR user_id_main = '$search_field' OR home_path = '$search_field' OR home_cfg_id = '$search_field'
+			OR home_name = '$search_field' OR agent_ip = '$search_field' OR remote_server_name = '$search_field'
+			OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+			" : "")."
+	  ;");
    }
 	
 	public function changeLastParam($home_id,$json) {
@@ -2791,13 +2839,24 @@ class OGPDatabaseMySQL extends OGPDatabase
 		$this->query("INSERT INTO OGP_DB_PREFIXlogger (date, user_id, ip, message) VALUE (FROM_UNIXTIME(UNIX_TIMESTAMP(), '%d-%m-%Y %H:%i:%s'), $user_id, '$client_ip', '$message');");
 	}
 
-	public function get_logger_count(){
-		return $this->resultQuery("SELECT COUNT(log_id) AS total FROM `".$this->table_prefix."logger`;");
+	public function get_logger_count($search_field){
+		return $this->resultQuery("SELECT COUNT(log_id) AS total FROM `".$this->table_prefix."logger` 
+		".($search_field ? " WHERE log_id = '$search_field' OR user_id = '$search_field' 
+		 OR ip = '$search_field' OR message = '$search_field' OR user_id
+		 IN 
+		 (SELECT user_id FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')" : "")."
+		;");
 	}
 	
-	public function read_logger($page,$limit){
+	public function read_logger($page,$limit,$search_field){
 		$log_id = ($page - 1) * $limit;
-		return $this->resultQuery("SELECT * FROM `".$this->table_prefix."logger` ORDER BY log_id DESC LIMIT $log_id,$limit;");
+		return $this->resultQuery("SELECT * FROM `".$this->table_prefix."logger` 
+		".($search_field ? " WHERE log_id = '$search_field' OR date = '$search_field'
+		 OR user_id = '$search_field' OR ip = '$search_field' OR message = '$search_field' OR user_id 
+		 IN 
+		 (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')" : "")." 
+		ORDER BY log_id DESC LIMIT $log_id,$limit;
+		");
 	}
 	
 	public function del_logger_log($log_id){

--- a/includes/database_mysqli.php
+++ b/includes/database_mysqli.php
@@ -1398,7 +1398,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id,$search_field){
 		if ( $id_type == "admin" )
 		{
-			return $this->resultQuery('SELECT COUNT(distinct(home_id)) AS total FROM `'.$this->table_prefix.'server_homes`
+			return $this->resultQuery('SELECT COUNT('.($search_field ?'distinct':'').' home_id) AS total FROM `'.$this->table_prefix.'server_homes`
 			'.($search_field ? '
 			NATURAL JOIN `'.$this->table_prefix.'user_homes`
 			NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
@@ -1411,24 +1411,72 @@ class OGPDatabaseMySQL extends OGPDatabase
  								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
  								OR user_id = '$search_field'
  								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
- 								OR port = '$search_field'
+ 								OR agent_ip = '$search_field' OR port = '$search_field'
  								" : '')." ": '
  			'.($search_field ?" WHERE home_cfg_id = '$home_cfg_id' OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
  								OR home_name = '$search_field' 
  								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
  								OR user_id = '$search_field'
 								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
-								OR port = '$search_field'
+								OR agent_ip = '$search_field' OR port = '$search_field'
 								" : '').'
 								'));
 		}
 		else if ( $id_type == "user_and_group" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_homes` WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
+			return $this->resultQuery('SELECT COUNT('.($search_field ?'distinct':'').' home_id) AS total FROM `'.$this->table_prefix.'user_homes`
+			'.($search_field ? '
+			NATURAL JOIN `'.$this->table_prefix.'server_homes`
+			NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
+ 			NATURAL JOIN `'.$this->table_prefix.'home_ip_ports`
+			' : '').'
+			WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id`
+			IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.'
+			'.($search_field ?" AND home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+ 								OR home_name = '$search_field' 
+ 								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR user_id = '$search_field'
+ 								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR agent_ip = '$search_field' OR port = '$search_field'
+ 								" : '').')'
+								: 
+								'
+				 			'.($search_field ?" AND home_cfg_id = '$home_cfg_id' OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+ 								OR home_name = '$search_field' 
+ 								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR user_id = '$search_field'
+								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+								OR agent_ip = '$search_field' OR port = '$search_field'
+								" : '').'				
+								' 
+								));
+		
+		
 		}
 		else if ( $id_type == "subuser" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_group_homes` WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
+			return $this->resultQuery('SELECT COUNT('.($search_field ?'distinct':'').' home_id) AS total FROM `'.$this->table_prefix.'user_group_homes`
+			'.($search_field ? '
+			NATURAL JOIN `'.$this->table_prefix.'user_homes`
+			NATURAL JOIN `'.$this->table_prefix.'server_homes`
+			NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
+ 			NATURAL JOIN `'.$this->table_prefix.'home_ip_ports`
+			' : '').'			
+			WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )
+			
+			' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.'
+			'.($search_field ?" AND home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+ 								OR home_name = '$search_field' 
+ 								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR agent_ip = '$search_field' OR port = '$search_field'
+ 								" : '').')'
+			:'
+			'.($search_field ?" AND home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
+ 								OR home_name = '$search_field' 
+ 								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
+ 								OR agent_ip = '$search_field' OR port = '$search_field'
+ 								" : '').'
+			'));
 		}		
 		
 	}
@@ -1437,7 +1485,8 @@ class OGPDatabaseMySQL extends OGPDatabase
 	$gethome_page_forlimit = ($home_page - 1) * $home_limit;	
 		if ( $id_type == "admin" )
 		{
-			$template = 'SELECT	%1$sserver_homes.*, 
+			$template = 'SELECT '.($search_field ?'distinct':'').' 
+								%1$sserver_homes.*, 
 								%1$sremote_servers.*, 
 								%1$sconfig_homes.*, 
 								%1$shome_ip_ports.port,
@@ -1473,19 +1522,16 @@ class OGPDatabaseMySQL extends OGPDatabase
 							FROM `%1$shome_ip_ports`
 							WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 						)
-						
 						'.($home_cfg_id ? '
 						AND %1$sserver_homes.home_cfg_id = \''.$home_cfg_id.'\'
-						
 						'.($search_field ?'
-						
 						AND %1$sserver_homes.home_id = \''.$search_field.'\'
 						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
 						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
 						OR user_id = \''.$search_field.'\'
 						OR user_id IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
 						OR home_name = \''.$search_field.'\'
-						OR port = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
 						' : '').'
 						'
 						: 
@@ -1497,7 +1543,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 						OR user_id = \''.$search_field.'\'
 						OR user_id IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
 						OR home_name = \''.$search_field.'\'
-						OR port = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
 						' : '').'
 						').' OR %1$shome_ip_ports.force_mod_id IS NULL LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 						
@@ -1526,7 +1572,8 @@ class OGPDatabaseMySQL extends OGPDatabase
 		}
 		else if ( $id_type == "user_and_group" )
 		{
-			$template = 'SELECT	%1$suser_homes.*, 
+			$template = 'SELECT	'.($search_field ?'distinct':'').'
+								%1$suser_homes.*, 
 								%1$sserver_homes.*, 
 								%1$sremote_servers.*, 
 								%1$sconfig_homes.*, 
@@ -1564,11 +1611,32 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
+						'.($home_cfg_id ? '
+						AND %1$sserver_homes.home_cfg_id = \''.$home_cfg_id.'\'
+						'.($search_field ?'
+						AND %1$sserver_homes.home_id = \''.$search_field.'\'
+						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
+						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR user_id = \''.$search_field.'\'
+						OR user_id IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR home_name = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
+						' : '').' ' : '
+						'.($search_field ?'
+						AND %1$sserver_homes.home_id = \''.$search_field.'\'
+						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
+						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR user_id = \''.$search_field.'\'
+						OR user_id IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR home_name = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
+						' : '').'
+						').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL
 						)
 						UNION
-						SELECT	%1$suser_group_homes.*,
+						SELECT	'.($search_field ?'distinct':'').'
+								%1$suser_group_homes.*,
 								%1$sserver_homes.*, 
 								%1$sremote_servers.*, 
 								%1$sconfig_homes.*, 
@@ -1589,7 +1657,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								%1$sconfig_mods.def_precmd,
 								%1$sconfig_mods.def_postcmd,
 								%1$sconfig_mods.mod_cfg_id
-						FROM %1$sremote_servers 
+						FROM %1$sremote_servers
 						NATURAL JOIN %1$suser_group_homes 
 						NATURAL JOIN %1$sserver_homes 
 						NATURAL JOIN %1$sconfig_homes
@@ -1611,8 +1679,24 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
-							OR %1$shome_ip_ports.force_mod_id IS NULL
+						'.($home_cfg_id ? '
+						AND %1$sserver_homes.home_cfg_id = \''.$home_cfg_id.'\'
+						'.($search_field ?'
+						AND %1$sserver_homes.home_id = \''.$search_field.'\'
+						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
+						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR home_name = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
+						' : '').' ' : '
+						'.($search_field ?'
+						AND %1$sserver_homes.home_id = \''.$search_field.'\'
+						OR user_id_main = \''.$search_field.'\' OR home_path = \''.$search_field.'\'
+						OR user_id_main IN (SELECT `user_id` FROM `%1$susers` WHERE users_login = \''.$search_field.'\')
+						OR home_name = \''.$search_field.'\'
+						OR agent_ip = \''.$search_field.'\' OR port = \''.$search_field.'\'
+						' : '').'
+						').'
+							OR %1$shome_ip_ports.force_mod_id IS NULL 
 						) 
 						LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 		}

--- a/includes/database_mysqli.php
+++ b/includes/database_mysqli.php
@@ -1395,44 +1395,23 @@ class OGPDatabaseMySQL extends OGPDatabase
 		}
 	}
 	
-	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id,$search_field){
+	public function getHomesFor_count($id_type,$assign_id,$home_cfg_id){
 		if ( $id_type == "admin" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'server_homes` 
-			NATURAL JOIN `'.$this->table_prefix.'user_homes` NATURAL JOIN `'.$this->table_prefix.'remote_servers` 
-			NATURAL JOIN `'.$this->table_prefix.'home_ip_ports`'  
-			
-			.($home_cfg_id ?" WHERE home_cfg_id = '$home_cfg_id'
-			".($search_field ?" OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
-								OR home_name = '$search_field' 
-								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
-								OR user_id = '$search_field'
-								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
-								OR port = '$search_field'
-								" : '') 
-			
-			: '
-			
-			'.($search_field ?" WHERE home_cfg_id = '$home_cfg_id' OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path = '$search_field' 
-								OR home_name = '$search_field' 
-								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
-								OR user_id = '$search_field'
-								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login = '$search_field')
-								OR port = '$search_field'
-								" : '').''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'server_homes`' . ($home_cfg_id ?' WHERE home_cfg_id = '.$home_cfg_id : ''));
 		}
 		else if ( $id_type == "user_and_group" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_homes` WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' '.($search_field ? ' AND home_cfg_id = '.$search_field.'' : '').' )':''.($search_field ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$search_field.')' : '').''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_homes` WHERE user_id = '.$assign_id.' ' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
 		}
 		else if ( $id_type == "subuser" )
 		{
-			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_group_homes` WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' '.($search_field ? ' AND home_cfg_id = '.$search_field.'' : '').' )': ''.($search_field ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$search_field.')' : '').''));
+			return $this->resultQuery('SELECT COUNT(home_id) AS total FROM `'.$this->table_prefix.'user_group_homes` WHERE group_id IN (SELECT group_id FROM `'.$this->table_prefix.'user_groups` WHERE user_id = '.$assign_id.' )' .($home_cfg_id ? 'AND `home_id` IN (SELECT `home_id` FROM `'.$this->table_prefix.'server_homes` WHERE home_cfg_id = '.$home_cfg_id.' )': ''));
 		}		
 		
 	}
 	
-	public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id,$search_field){
+	public function getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id){
 	$gethome_page_forlimit = ($home_page - 1) * $home_limit;	
 		if ( $id_type == "admin" )
 		{
@@ -1471,18 +1450,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 							FROM `%1$shome_ip_ports`
 							WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 						)
-						'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.'
-						
-						'.($search_field ?' OR %1$sserver_homes.home_id = \''.$search_field.'\' OR %1$sserver_homes.user_id_main = \''.$search_field.'\'
-						 OR %1$sserver_homes.home_path = \''.$search_field.'\' OR %1$sserver_homes.home_name = \''.$search_field.'\'
-						 OR user_id_main IN (SELECT `user_id` FROM `'.$this->table_prefix.'users` WHERE users_login = \''.$search_field.'\')
-						 OR %1$shome_ip_ports.port = \''.$search_field.'\'' : '')
-						: '
-						'.($search_field ?' OR %1$sserver_homes.home_id = \''.$search_field.'\' OR %1$sserver_homes.user_id_main = \''.$search_field.'\'
-						 OR %1$sserver_homes.home_path = \''.$search_field.'\' OR %1$sserver_homes.home_name = \''.$search_field.'\'
-						 OR user_id_main IN (SELECT `user_id` FROM `'.$this->table_prefix.'users` WHERE users_login = \''.$search_field.'\')
-						 OR %1$shome_ip_ports.port = \''.$search_field.'\'' : '').'').'
-						 
+						'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
 						OR %1$shome_ip_ports.force_mod_id IS NULL LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 						
 			$template2 = 'SELECT user_expiration_date, home_id FROM %1$suser_homes WHERE user_id = %2$d;';
@@ -1498,7 +1466,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 				%1$suser_homes.user_expiration_date, %1$sremote_servers.*, %1$sconfig_homes.*
 				FROM %1$sremote_servers NATURAL JOIN %1$suser_homes
 				NATURAL JOIN %1$sserver_homes NATURAL JOIN %1$sconfig_homes
-				WHERE %1$suser_homes.user_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
+				WHERE %1$suser_homes.user_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 		}
 		else if ( $id_type == "group" )
 		{
@@ -1506,7 +1474,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 				%1$suser_group_homes.user_group_expiration_date, %1$sremote_servers.*, %1$sconfig_homes.*
 				FROM %1$sremote_servers NATURAL JOIN %1$suser_group_homes
 				NATURAL JOIN %1$sserver_homes NATURAL JOIN %1$sconfig_homes
-				WHERE %1$suser_group_homes.group_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
+				WHERE %1$suser_group_homes.group_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';
 		}
 		else if ( $id_type == "user_and_group" )
 		{
@@ -1548,7 +1516,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').'
+							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL
 						)
 						UNION
@@ -1595,7 +1563,7 @@ class OGPDatabaseMySQL extends OGPDatabase
 								FROM `%1$shome_ip_ports`
 								WHERE `force_mod_id` = %1$sgame_mods.mod_id OR %1$shome_ip_ports.force_mod_id = 0
 							)
-							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').'
+							'.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id : '').'
 							OR %1$shome_ip_ports.force_mod_id IS NULL
 						) 
 						LIMIT '.$gethome_page_forlimit.','.$home_limit.';';

--- a/modules/administration/watch_logger.php
+++ b/modules/administration/watch_logger.php
@@ -30,9 +30,12 @@ function exec_ogp_module() {
 	<table style="width: 100%;">
 		<tr>
 			<td style="width: 50%; vertical-align: middle; text-align: left;">
-				<form onsubmit="event.preventDefault();" style="display: inline;">
+				<form action="home.php" method="GET" style="display: inline;">
 					<b><?php print_lang('search'); ?>:</b>
-					<input type="text" id="search">
+					<input type ="hidden" name="m" value="administration" />
+					<input type ="hidden" name="p" value="watch_logger" />
+					<input name="search" type="text" id="search">
+					<input type="submit" value="search" />
 				</form>
 				<form method=POST style="display: inline;">
 					<input type="submit" name="empty_logger" value="<?php print_lang('empty_logger'); ?>" >
@@ -62,6 +65,7 @@ function exec_ogp_module() {
 	if( isset( $_POST['empty_logger'] ) )
 		$db->empty_logger();
 	
+	$search_field = (isset($_GET['search']) && !empty($_GET['search'])) ? $_GET['search'] : false;
 	$p = (isset($_GET['page']) && (int)$_GET['page'] > 0) ? (int)$_GET['page'] : 1;
 	$l = (isset($_GET['limit']) && (int)$_GET['limit'] > 0) ? (int)$_GET['limit'] : 10;
 	
@@ -69,7 +73,7 @@ function exec_ogp_module() {
 		$l = $loggedInUserInfo["users_page_limit"];
 	}
 	
-	$logs = $db->read_logger($p,$l);
+	$logs = $db->read_logger($p,$l,$search_field);
 	
 	if($logs)
 	{
@@ -115,9 +119,14 @@ function exec_ogp_module() {
 	echo "</tbody>\n";
 	echo "<tfoot style='border:1px solid grey;'></tfoot>\n";
 	echo "</table>\n";
-	$count_logs = $db->get_logger_count();
-
+	$count_logs = $db->get_logger_count($search_field);
+	
+	if(isset($_GET['search']) && !empty($_GET['search'])){
+	$uri = '?m=administration&p=watch_logger&search='.$_GET['search'].'&limit='.$l.'&page=';
+	}
+	else{
 	$uri = '?m=administration&p=watch_logger&limit='.$l.'&page=';
+	}
 	echo paginationPages($count_logs[0]['total'], $p, $l, $uri, 3, 'watchLogger');
 }
 ?>

--- a/modules/gamemanager/server_monitor.php
+++ b/modules/gamemanager/server_monitor.php
@@ -129,6 +129,9 @@ function exec_ogp_module() {
 	$home_limit = (isset($_GET['limit']) && (int)$_GET['limit'] > 0) ? (int)$_GET['limit'] : 10;
 	$home_cfg_id = (isset($_GET['home_cfg_id']) && (int)$_GET['home_cfg_id'] > 0) ? (int)$_GET['home_cfg_id'] : false;
 	
+	$search_field = (isset($_GET['search']) && !empty($_GET['search'])) ? $_GET['search'] : false;
+	
+	
 	if(hasValue($loggedInUserInfo) && is_array($loggedInUserInfo) && $loggedInUserInfo["users_page_limit"] && !hasValue($_GET['limit'])){
 		$home_limit = $loggedInUserInfo["users_page_limit"];
 	}
@@ -141,7 +144,7 @@ function exec_ogp_module() {
 			if(isset($_GET['home_id']) OR isset($_GET['home_id-mod_id-ip-port']))          
 				$server_homes = $db->getHomesFor('admin', $_SESSION['user_id']);
 			else
-				$server_homes = $db->getHomesFor_limit('admin', $_SESSION['user_id'],$home_page,$home_limit,$home_cfg_id);
+				$server_homes = $db->getHomesFor_limit('admin', $_SESSION['user_id'],$home_page,$home_limit,$home_cfg_id,$search_field);
 	
 		}
 		else
@@ -150,7 +153,7 @@ function exec_ogp_module() {
 			if(isset($_GET['home_id']) OR isset($_GET['home_id-mod_id-ip-port']))          
 				$server_homes = $db->getHomesFor('user_and_group', $_SESSION['user_id']);
 			else			
-				$server_homes = $db->getHomesFor_limit('user_and_group', $_SESSION['user_id'],$home_page,$home_limit,$home_cfg_id);
+				$server_homes = $db->getHomesFor_limit('user_and_group', $_SESSION['user_id'],$home_page,$home_limit,$home_cfg_id,$search_field);
 		}
 
 	if( $server_homes === FALSE )
@@ -165,9 +168,12 @@ function exec_ogp_module() {
 		return;
 	}
 	?>
-		<form onsubmit="event.preventDefault();" style="float:right;">
+		<form action="home.php" style="float:right;">
 			<b><?php print_lang('search'); ?>:</b>
-			<input type="text" id="search">
+			<input type ="hidden" name="m" value="gamemanager" />
+			<input type ="hidden" name="p" value="game_monitor" />
+			<input name="search" type="text" id="search">
+			<input type="submit" value="search" />
 		</form>
 	<?php
 	foreach($_POST as $key => $value)
@@ -623,23 +629,23 @@ function exec_ogp_module() {
 	echo "</table>";
 
 	if ($isAdmin) {	
-		$homes_count = $db->getHomesFor_count('admin', $_SESSION['user_id'], $home_cfg_id);
+		$homes_count = $db->getHomesFor_count('admin', $_SESSION['user_id'], $home_cfg_id,$search_field);
 	} else {
 		$isSubUser = $db->isSubUser($_SESSION['user_id']);
 
 		if ($isSubUser) {
-			$homes_count = $db->getHomesFor_count('subuser',$_SESSION['user_id'], $home_cfg_id);
+			$homes_count = $db->getHomesFor_count('subuser',$_SESSION['user_id'], $home_cfg_id,$search_field);
 		} else {
-			$homes_count = $db->getHomesFor_count('user_and_group',$_SESSION['user_id'], $home_cfg_id);
+			$homes_count = $db->getHomesFor_count('user_and_group',$_SESSION['user_id'], $home_cfg_id,$search_field);
 		}	
 	}
 
 
 	if(isset($_GET['home_cfg_id']) && !empty($_GET['home_cfg_id'])){
-	$uri = '?m=gamemanager&p=game_monitor&home_cfg_id='.$_GET['home_cfg_id'].'&limit='.$home_limit.'&page=';
+	$uri = '?m=gamemanager&p=game_monitor&home_cfg_id='.$_GET['home_cfg_id'].''.($search_field ? "&search=$search_field" : "").'&limit='.$home_limit.'&page=';
 	}
 	else{
-	$uri = '?m=gamemanager&p=game_monitor&limit='.$home_limit.'&page=';	
+	$uri = '?m=gamemanager&p=game_monitor'.($search_field ? "&search=$search_field" : "").'&limit='.$home_limit.'&page=';	
 	}
 	
 	if(!isset($_GET['home_id-mod_id-ip-port']) && !isset($_GET['home_id']))

--- a/modules/user_admin/show_users.php
+++ b/modules/user_admin/show_users.php
@@ -49,20 +49,27 @@ function exec_ogp_module() {
 	
 	$page_user = (isset($_GET['page']) && (int)$_GET['page'] > 0) ? (int)$_GET['page'] : 1;
 	$limit_user = (isset($_GET['limit']) && (int)$_GET['limit'] > 0) ? (int)$_GET['limit'] : 10;
+	$search_field = (isset($_GET['search']) && !empty($_GET['search'])) ? $_GET['search'] : false;
 	
 	if(hasValue($loggedInUserInfo) && is_array($loggedInUserInfo) && $loggedInUserInfo["users_page_limit"] && !hasValue($_GET['limit'])){
 		$limit_user = $loggedInUserInfo["users_page_limit"];
 	}
 	
     echo '<h2>'.get_lang('users')."</h2>";
-	echo "<p><a href='?m=user_admin&amp;p=add'>".get_lang('add_new_user')."</a></p>";
-    echo '<table class="userListTable center" style="width: 100%;">';
+	echo '<form action="home.php" method="GET" style="float:left;">
+		<p><a href="?m=user_admin&amp;p=add">'.get_lang("add_new_user").'</a></p>
+		<input type ="hidden" name="m" value="user_admin" />
+		<input name="search" type="text" id="search" />
+		<input type="submit" value="search" />
+		</form>';
+    echo '<table class="userListTable center" style="width: 100%;margin-top:100px;">';
     echo '<tr><th>'.get_lang('actions')."</th><th>".get_lang('username')."</th>";
     echo "<th>".get_lang('user_role')."</th>";
     echo "<th>".get_lang('email_address')."</th>";
     echo "<th>".get_lang('expires')."</th>";
     echo "<th class='subuserColumn'>".get_lang('subusers')."</th></tr>";
-    $result = $db->getUserList_limit($page_user,$limit_user);
+
+    $result = $db->getUserList_limit($page_user,$limit_user,$search_field);
     $i = 0;
     foreach ( $result as $row )
     {
@@ -100,9 +107,14 @@ function exec_ogp_module() {
     }
     echo '</table><br>';
 
-	$count_users = $db->get_user_count();
+	$count_users = $db->get_user_count($search_field);
 	
+	if(isset($_GET['search']) && !empty($_GET['search'])){
+	$uri = '?m=user_admin&search='.$_GET['search'].'&limit='.$limit_user.'&page=';
+	}
+	else{
 	$uri = '?m=user_admin&limit='.$limit_user.'&page=';
+	}
 	echo paginationPages($count_users[0]['total'], $page_user, $limit_user, $uri, 3, 'userManager');
 	
 }

--- a/modules/user_games/show_homes.php
+++ b/modules/user_games/show_homes.php
@@ -25,7 +25,8 @@
 function exec_ogp_module()
 {
 	global $db, $loggedInUserInfo;
-
+	$search_field = (isset($_GET['search']) && !empty($_GET['search'])) ? $_GET['search'] : false;
+	
 	$page_GameHomes = (isset($_GET['page']) && (int)$_GET['page'] > 0) ? (int)$_GET['page'] : 1;
 	$limit_GameHomes = (isset($_GET['limit']) && (int)$_GET['limit'] > 0) ? (int)$_GET['limit'] : 10;
 	
@@ -34,9 +35,14 @@ function exec_ogp_module()
 	}
 	
 	echo "<h2>".get_lang('game_servers')."</h2>";
-	echo "<p><a href='?m=user_games&amp;p=add'>".get_lang('add_new_game_home')."</a></p>";
+	echo '<form action="home.php" method="GET" style="margin-bottom:10px;float:left;">
+		<p><a href="?m=user_games&amp;p=add">'.get_lang("add_new_game_home").'</a></p>
+		<input type ="hidden" name="m" value="user_games" />
+		<input name="search" type="text" id="search" />
+		<input type="submit" value="search" />
+		</form>';	
 
-	$game_homes = $db->getGameHomes_limit($page_GameHomes,$limit_GameHomes);
+	$game_homes = $db->getGameHomes_limit($page_GameHomes,$limit_GameHomes,$search_field);
 	if ( empty($game_homes) )
 	{
 		echo "<p>".get_lang('no_game_homes_found')."</p>";
@@ -74,9 +80,16 @@ function exec_ogp_module()
 	
 	echo "</table>";
 
-	$count_GameHomes = $db->get_GameHomes_count();
-
+	$count_GameHomes = $db->get_GameHomes_count($search_field);
+	
+	if(isset($_GET['search']) && !empty($_GET['search'])){
+	$uri = '?m=user_games&search='.$_GET['search'].'&limit='.$limit_GameHomes.'&page=';
+	}
+	else
+	{
 	$uri = '?m=user_games&limit='.$limit_GameHomes.'&page=';
+	}
+	
 	echo paginationPages($count_GameHomes[0]['total'], $page_GameHomes, $limit_GameHomes, $uri, 3, 'userGames');
 
 	?>


### PR DESCRIPTION
Hello every one, i made small query join to pagination count and select
value of certain search for watch_logger.php, show_homes.php,
show_users.php.
But we need to add search function to server_monitor.php too, but i
still faced some issue with display search result (Count for search
result not have problem with counting) by using this (in admin power),
search for function in pull request on `database_mysql.php `&
`database_mysqli.php`
` public function
getHomesFor_count($id_type,$assign_id,$home_cfg_id,$search_field){
if ( $id_type == "admin" )
{ `

and

`public function
getHomesFor_limit($id_type,$assign_id,$home_page,$home_limit,$home_cfg_id,$search_field){`

For this line:
`WHERE %1$suser_homes.user_id = %2$d '.($home_cfg_id ? 'AND %1$sserver_homes.home_cfg_id = '.$home_cfg_id.''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '') : ''.($search_field ?' AND %1$sserver_homes.home_cfg_id = '.$search_field.'' : '').'').' ORDER BY home_id ASC LIMIT '.$gethome_page_forlimit.','.$home_limit.';';`

that appear on `else if ( $id_type == "user" ) `& `else if ( $id_type == "group" )` & `else if ( $id_type == "user_and_group" )`

this lines just a test from me if the statement work or not so will be ignore it at these moment.

So let's do this together then accept this pull request.