### PR TITLE
ARK: Survival Evolved xml update

### DIFF
--- a/modules/config_games/server_configs/arkse_linux64.xml
+++ b/modules/config_games/server_configs/arkse_linux64.xml
@@ -5,7 +5,7 @@
   <installer>steamcmd</installer>
   <game_name>ARK: Survival Evolved</game_name>
   <server_exec_name>ShooterGameServer</server_exec_name>
-  <cli_template>%MAP%%IP%%PORT%%QUERY_PORT%%PLAYERS%%CONTROL_PASSWORD%%PDS%%PDI%%PDD%%PUS%%PUI%%PUD%%ASDN%%POP%%POPI%%PTA%?listen %AMM% %CDO% %CID% %FACF% %NTFF% -server -log</cli_template>
+  <cli_template>%MAP%%IP%%PORT%%QUERY_PORT%%PLAYERS%%RCON%%CONTROL_PASSWORD%%PDS%%PDI%%PDD%%PUS%%PUI%%PUD%%ASDN%%POP%%POPI%%PTA%?listen %AMM% %CDO% %CID% %FACF% %NTFF% -server -log</cli_template>
   <cli_params>
     <cli_param id="MAP" cli_string="" />
     <cli_param id="IP" cli_string="?Multihome=" />
@@ -35,6 +35,12 @@
     </text>
   </replace_texts>
   <server_params>
+    <param key="?RCONEnabled=" type="select" id="RCON">
+      <option value="True">True</option>
+      <option value="False">False</option>
+      <options>ns</options>
+      <desc>Enable or disable remote control.</desc>
+    </param>
     <param key="-automanagedmods" type="checkbox_key_value" id="AMM">
       <desc>Enable automatic MOD downloading, installing and updating.</desc>
     </param>
@@ -118,16 +124,6 @@
     </param>
   </server_params>
   <custom_fields>
-    <field key="Enable RCON" type="select">
-      <option value="True">Yes</option>
-      <option value="False">No</option>
-      <default>RCONEnabled=.*</default>
-      <default_value>True</default_value>
-      <var>RCONEnabled=</var>
-      <filepath>ShooterGame/Saved/Config/LinuxServer/GameUserSettings.ini</filepath>
-      <options>sq</options>
-      <desc>Enable or disable remote control.</desc>
-    </field>
     <field key="RCON Port" type="text">
       <default>RCONPort=.*</default>
       <default_value>27020</default_value>

--- a/modules/config_games/server_configs/arkse_win64.xml
+++ b/modules/config_games/server_configs/arkse_win64.xml
@@ -5,7 +5,7 @@
   <installer>steamcmd</installer>
   <game_name>ARK: Survival Evolved</game_name>
   <server_exec_name>ShooterGameServer.exe</server_exec_name>
-  <cli_template>%MAP%%IP%%PORT%%QUERY_PORT%%PLAYERS%%CONTROL_PASSWORD%%PDS%%PDI%%PDD%%PUS%%PUI%%PUD%%ASDN%%POP%%POPI%%PTA%?listen %AMM% %CDO% %CID% %FACF% %NTFF% -server -log</cli_template>
+  <cli_template>%MAP%%IP%%PORT%%QUERY_PORT%%PLAYERS%%RCON%%CONTROL_PASSWORD%%PDS%%PDI%%PDD%%PUS%%PUI%%PUD%%ASDN%%POP%%POPI%%PTA%?listen %AMM% %CDO% %CID% %FACF% %NTFF% -server -log</cli_template>
   <cli_params>
     <cli_param id="MAP" cli_string="" />
     <cli_param id="IP" cli_string="?Multihome=" />
@@ -35,6 +35,12 @@
     </text>
   </replace_texts>
   <server_params>
+    <param key="?RCONEnabled=" type="select" id="RCON">
+      <option value="True">True</option>
+      <option value="False">False</option>
+      <options>ns</options>
+      <desc>Enable or disable remote control.</desc>
+    </param>
     <param key="-automanagedmods" type="checkbox_key_value" id="AMM">
       <desc>Enable automatic MOD downloading, installing and updating.</desc>
     </param>
@@ -118,16 +124,6 @@
     </param>
   </server_params>
   <custom_fields>
-    <field key="Enable RCON" type="select">
-      <option value="True">Yes</option>
-      <option value="False">No</option>
-      <default>RCONEnabled=.*</default>
-      <default_value>True</default_value>
-      <var>RCONEnabled=</var>
-      <filepath>ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini</filepath>
-      <options>sq</options>
-      <desc>Enable or disable remote control.</desc>
-    </field>
     <field key="RCON Port" type="text">
       <default>RCONPort=.*</default>
       <default_value>27020</default_value>


### PR DESCRIPTION
Fixed RCONEnable option. If the server config file doesn't have this parameter, then it is not possible to change that, therefore I moved it to the server startup parameters.