### PR TITLE
Minor Change for Compatibility on PHP 5.3 Installs

### DIFF
--- a/modules/extras/extras.php
+++ b/modules/extras/extras.php
@@ -267,7 +267,7 @@ function exec_ogp_module()
 			return;
 		}
 		
-		$back_compatibility = [ 'Util',
+		$back_compatibility = array ( 'Util',
 								'RCON',
 								'DSi',
 								'Cron',
@@ -282,7 +282,7 @@ function exec_ogp_module()
 								'Light',
 								'Silver',
 								'Soft',
-								'Uprise' ];
+								'Uprise' );
 		
 		$installed = rglob('*/*/install.nfo');
 		


### PR DESCRIPTION
The minimal version supported is 5.3. As such, anyone using that version will encounter a syntax error when loading the extras module due to the shorthand array syntax.

It seems this has been present since the migration to Github from looking over the commit history.

Fixes http://www.opengamepanel.org/forum/viewthread.php?thread_id=5507&pid=27752