### PR TITLE
MaxPermSize=128M support was removed in 8.0

### DIFF
--- a/modules/config_games/server_configs/spigotmc_linux.xml
+++ b/modules/config_games/server_configs/spigotmc_linux.xml
@@ -4,7 +4,7 @@
   <gameq_query_name>minecraft</gameq_query_name>
   <game_name>Spigot Server</game_name>
   <server_exec_name>spigot_run</server_exec_name>
-  <cli_template>-Xincgc %XMX% -XX:MaxPermSize=128M -jar spigot.jar nogui</cli_template>
+  <cli_template>-Xincgc %XMX% -jar spigot.jar nogui</cli_template>
   <max_user_amount>32</max_user_amount>
   <!-- <control_protocol>lcon</control_protocol> Enables legacy console, the output will be shown in the log file-->
   <mods>


### PR DESCRIPTION
This parameter is deprecated and is no longer used in Java 8