### PR TITLE
Update extras.php

### DIFF
--- a/modules/extras/extras.php
+++ b/modules/extras/extras.php
@@ -304,7 +304,7 @@ function exec_ogp_module()
 	}
 	#return;
 	define('REPO_FILE', DATA_PATH . "repos" . "_" . strtolower($gitHubOrganization));
-	define('URL', 'https://api.github.com/' . $gitAPICont . '/' . $gitHubOrganization . '/repos'); // Returns detailed information of all repositories, and urls for more detailed informations about. Nice API GitHub! :)
+	define('URL', 'https://api.github.com/' . $gitAPICont . '/' . $gitHubOrganization . '/repos?per_page=50'); // Returns detailed information of all repositories, and urls for more detailed informations about. Nice API GitHub! :)
 	if(!file_exists(REPO_FILE) || isset($_GET['searchForUpdates']) || isset($_POST['update']) || filesize(REPO_FILE) == 0 || filesize(REPO_FILE) == 1 || (time() - filemtime(REPO_FILE)) >= 86400)
 	{
 		# Without this $context the file_get_contents function was returning HTTP/1.0 403 Forbidden


### PR DESCRIPTION
The Github API limits results to 30 per request. There's 31 repositories now, so one is cut out from being shown in the Extras Module.

Additional results may be viewed via adding `?per_page=` or the `?page=` parameters. The complete number of pages can be known from the response headers.

```
Link: <https://api.github.com/organizations/6736445/repos?page=2>; rel="next", <https://api.github.com/organizations/6736445/repos?page=2>; rel="last"
```

This will do as a quick fix for now. If necessary, then later loop through the pages.