### PR TITLE
Additional Mirrors

### DIFF
--- a/modules/gamemanager/rsync_sites.list
+++ b/modules/gamemanager/rsync_sites.list
@@ -1,2 +1,4 @@
 rsync.opengamepanel.org|New York USA
 atl.webehostin.com|Atlanta Georgia USA
+ogp-us.mirror.adjo.me|Atlanta Georgia USA
+ogp-nl.mirror.adjo.me|Amsterdam NL


### PR DESCRIPTION
There was previously quite a few dead mirrors which I'd been meaning to replace.

I've set up two on some unused VMs. One in The Netherlands and one in Atlanta. The NL mirror will sync from the US mirror.

Additionally, the files may also be downloaded / served via HTTP.

[ogp-us.mirror.adjo.me](http://ogp-us.mirror.adjo.me)
[ogp-nl.mirror.adjo.me](http://ogp-nl.mirror.adjo.me)