### PR TITLE
MySQL Admin Module Fix

### DIFF
--- a/modules/mysql/mysql_database.php
+++ b/modules/mysql/mysql_database.php
@@ -24,9 +24,8 @@
 
 class MySQLModuleDatabase extends OGPDatabaseMySQL
 {
-	private $link;
-
-    private $table_prefix;
+	protected $link;
+	protected $table_prefix;
 	
 	public function __construct() {
         

--- a/modules/mysql/mysqli_database.php
+++ b/modules/mysql/mysqli_database.php
@@ -24,9 +24,8 @@
 
 class MySQLModuleDatabase extends OGPDatabaseMySQL
 {
-	private $link;
-
-    private $table_prefix;
+	protected $link;
+	protected $table_prefix;
 	
 	public function __construct() {
         


### PR DESCRIPTION
The recent change in the database class broke this module, mentioned [here](http://www.opengamepanel.org/forum/viewthread.php?thread_id=5351&rowstart=20&showlast=true#post_29475)

When it's loaded, a fatal error appears as the scope of `$link` and `$table_prefix` needs to match that of `OGPDatabaseMySQL`

```
Fatal Error: Access level to MySQLModuleDatabase::$link must be protected (as in class OGPDatabaseMySQL) or weaker
```