### PR TITLE
Make Extras modules update result more readable

### DIFF
--- a/modules/extras/extras.php
+++ b/modules/extras/extras.php
@@ -168,16 +168,19 @@ function installUpdate($info, $base_dir, $current_blacklist = array())
 			if ( $overwritten > 0 )
 			{
 				echo get_lang_f('files_overwritten',$overwritten).":\n\n".$overwritten_files;
+				echo "\n\n";
 			}
 			
 			if ( $new > 0 )
 			{
 				echo get_lang_f('new_files',$new).":\n\n".$new_files;
+				echo "\n\n";
 			}
 			
 			if ( $not_overwritten > 0 )
 			{
 				echo get_lang_f('files_not_overwritten',$not_overwritten).":\n\n".$not_overwritten_files;
+				echo "\n\n";
 			}
 						
 			// Add install.nfo file to the module/theme directory so we can remove the installed files later and check the installed files timestamp.


### PR DESCRIPTION
separate each group (overwritten, new, not overwritten, and module version), with two lines space to make it more readable instead of having the next group right after the last filename of previous group.

before: https://www.dropbox.com/s/4pv01v2sen1hekd/Capture%20d%27%C3%A9cran%202017-10-27%2020.37.19.png?dl=0
now: https://www.dropbox.com/s/xxi4zi4c7mx2hgc/Capture%20d%27%C3%A9cran%202017-10-27%2020.53.37.png?dl=0