### PR TITLE
getGameHomes_limit Search Changes

### DIFF
--- a/includes/database.php
+++ b/includes/database.php
@@ -277,7 +277,7 @@ abstract class OGPDatabase {
 
     abstract public function getGameHomes();
     
-    abstract public function getGameHomes_limit($page_gameHomes,$limit_gameHomes,$search_field);
+    abstract public function getGameHomes_limit($page_gameHomes, $limit_gameHomes, $searchType, $searchString);
 
     /// \return true If username and password match.
     /// \return false If username and password does not match

--- a/includes/database_mysqli.php
+++ b/includes/database_mysqli.php
@@ -1626,7 +1626,6 @@ class OGPDatabaseMySQL extends OGPDatabase
  								OR user_id = '$search_field'
  								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login LIKE '%".$search_field."%')
  								OR agent_ip = '$search_field' OR port = '$search_field'
- 								OR ip LIKE '%" . $search_field . "%' 
  								" : '')." ": '
  			'.($search_field ?" WHERE home_cfg_id = '$home_cfg_id' OR home_id = '$search_field' OR user_id_main = '$search_field' OR home_path LIKE '%".$search_field."%'
  								OR home_name LIKE '%".$search_field."%'
@@ -1634,7 +1633,6 @@ class OGPDatabaseMySQL extends OGPDatabase
  								OR user_id = '$search_field'
 								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login LIKE '%".$search_field."%')
 								OR agent_ip = '$search_field' OR port = '$search_field'
-								OR ip LIKE '%" . $search_field . "%' 
 								" : '').'
 								'));
 		}
@@ -1654,7 +1652,6 @@ class OGPDatabaseMySQL extends OGPDatabase
  								OR user_id = '$search_field'
  								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login LIKE '%".$search_field."%')
  								OR agent_ip = '$search_field' OR port = '$search_field'
- 								OR ip LIKE '%" . $search_field . "%' 
  								" : '').')'
 								: 
 								'
@@ -1664,7 +1661,6 @@ class OGPDatabaseMySQL extends OGPDatabase
  								OR user_id = '$search_field'
 								OR user_id IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login LIKE '%".$search_field."%')
 								OR agent_ip = '$search_field' OR port = '$search_field'
-								OR ip LIKE '%" . $search_field . "%' 
 								)" : '').'				
 								' 
 								));
@@ -1687,14 +1683,12 @@ class OGPDatabaseMySQL extends OGPDatabase
  								OR home_name LIKE '%".$search_field."%'
  								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login LIKE '%".$search_field."%')
  								OR agent_ip = '$search_field' OR port = '$search_field'
- 								OR ip LIKE '%" . $search_field . "%' 
  								" : '').')'
 			:'
 			'.($search_field ?" AND home_id = '$search_field' OR user_id_main = '$search_field' OR home_path LIKE '%".$search_field."%'
  								OR home_name LIKE '%".$search_field."%'
  								OR user_id_main IN (SELECT `user_id` FROM `".$this->table_prefix."users` WHERE users_login LIKE '%".$search_field."%')
  								OR agent_ip = '$search_field' OR port = '$search_field'
- 								OR ip LIKE '%" . $search_field . "%' 
  								" : '').'
 			'));
 		}		
@@ -2894,34 +2888,67 @@ class OGPDatabaseMySQL extends OGPDatabase
 		return $this->listQuery($query);
 	}
 	
-	public function getGameHomes_limit($page_gameHomes, $limit_gameHomes, $search_field) {
+	public function getGameHomes_limit($page_gameHomes, $limit_gameHomes, $searchType, $searchString) {
 		$game_home_id = ($page_gameHomes - 1) * $limit_gameHomes;
 		
-		$sql = 'SELECT %1$sserver_homes.*, %1$sremote_servers.*, %1$sconfig_homes.* FROM `%1$sserver_homes` NATURAL JOIN `%1$sconfig_homes` NATURAL JOIN `%1$sremote_servers` ';
+		$sql = 'SELECT %1$sserver_homes.*, %1$sremote_servers.*, %1$sconfig_homes.*, %1$shome_ip_ports.port
+					FROM `%1$sserver_homes`
+						NATURAL JOIN `%1$sconfig_homes`
+						NATURAL JOIN `%1$sremote_servers`
+						LEFT JOIN %1$shome_ip_ports 
+							NATURAL JOIN %1$sremote_server_ips ON %1$sserver_homes.home_id=%1$shome_ip_ports.home_id ';
 		
-		if (!empty($search_field)) {
-			$sql .= "WHERE home_id = '$search_field' OR remote_server_id = '$search_field'
-					OR user_id_main = '$search_field' OR home_path = '$search_field' OR home_cfg_id = '$search_field'
-					OR home_name LIKE '%%$search_field%%' OR agent_ip = '$search_field' OR remote_server_name LIKE '%%$search_field%%'
-					OR user_id_main IN (SELECT user_id FROM %1\$susers WHERE users_login LIKE '%%$search_field%%') 
-					OR ip LIKE '%%$search_field%% '";
+		if (!empty($searchString)) {
+			if ($searchType == 'ip_port') {
+				$sql .= "WHERE CONCAT_WS(':', %1\$sremote_server_ips.ip, %1\$shome_ip_ports.port) = '$searchString'
+							OR agent_ip = '$searchString' ";
+			}
+
+			if ($searchType == 'home_name') {
+				$sql .= "WHERE home_name LIKE '%%$searchString%%' ";
+			}
+			
+			if ($searchType == 'ownedBy') {
+				$sql .= "WHERE user_id_main IN (SELECT user_id FROM %1\$susers WHERE users_login LIKE '%%$searchString%%')
+							OR user_id_main = '$searchString' ";
+			}
+
+			if ($searchType == 'rserver') {
+				$sql .= "WHERE remote_server_name LIKE '%%$searchString%%'
+							OR %1\$sserver_homes.remote_server_id = '$searchString' ";
+			}
 		}
 
 		$sql .= "ORDER BY home_id ASC LIMIT $game_home_id, $limit_gameHomes;";
-
 		$sql = sprintf($sql, $this->table_prefix);
+
 		return $this->listQuery($sql);
 	}
 	
-	public function get_GameHomes_count($search_field) {
-		$sql = 'SELECT COUNT(1) AS total FROM %1$sserver_homes NATURAL JOIN %1$sremote_servers ';
+	public function get_GameHomes_count($searchType, $searchString) {
+		$sql = 'SELECT COUNT(1) AS total FROM %1$sserver_homes NATURAL JOIN %1$sremote_servers
+					LEFT JOIN %1$shome_ip_ports 
+						NATURAL JOIN %1$sremote_server_ips ON %1$sserver_homes.home_id=%1$shome_ip_ports.home_id ';
 
-		if (!empty($search_field)) {
-			$sql .= "WHERE home_id = '$search_field' OR remote_server_id = '$search_field'
-					OR user_id_main = '$search_field' OR home_path = '$search_field' OR home_cfg_id = '$search_field'
-					OR home_name LIKE '%%$search_field%%' OR agent_ip = '$search_field' OR remote_server_name LIKE '%%$search_field%%'
-					OR user_id_main IN (SELECT user_id FROM %1\$susers WHERE users_login LIKE '%%$search_field%%') 
-					OR ip LIKE '%%$search_field%% '";
+		if (!empty($searchString)) {
+			if ($searchType == 'ip_port') {
+				$sql .= "WHERE CONCAT_WS(':', %1\$sremote_server_ips.ip, %1\$shome_ip_ports.port) = '$searchString'
+							OR agent_ip = '$searchString' ";
+			}
+
+			if ($searchType == 'home_name') {
+				$sql .= "WHERE home_name LIKE '%%$searchString%%' ";
+			}
+			
+			if ($searchType == 'ownedBy') {
+				$sql .= "WHERE user_id_main IN (SELECT user_id FROM %1\$susers WHERE users_login LIKE '%%$searchString%%')
+							OR user_id_main = '$searchString' ";
+			}
+
+			if ($searchType == 'rserver') {
+				$sql .= "WHERE remote_server_name LIKE '%%$searchString%%'
+							OR %1\$sserver_homes.remote_server_id = '$searchString' ";
+			}
 		}
 
 		$sql = sprintf($sql, $this->table_prefix);

--- a/modules/administration/watch_logger.php
+++ b/modules/administration/watch_logger.php
@@ -38,10 +38,10 @@ function exec_ogp_module() {
 
 	$logs = $db->read_logger($p, $l, $search_field);
 
-	if (empty($logs)) {
+	if (empty($logs) && !empty($search_field)) {
 		print_failure(get_lang_f('no_results_found', htmlentities($search_field)));
-
 		$view->refresh("?m=administration&p=watch_logger", 5);
+
 		return;
 	}
 
@@ -130,11 +130,10 @@ function exec_ogp_module() {
 	echo "</table>\n";
 	$count_logs = $db->get_logger_count($search_field);
 	
-	if(isset($_GET['search']) && !empty($_GET['search'])){
-	$uri = '?m=administration&p=watch_logger&search='.$_GET['search'].'&limit='.$l.'&page=';
-	}
-	else{
-	$uri = '?m=administration&p=watch_logger&limit='.$l.'&page=';
+	if (isset($_GET['search']) && !empty($_GET['search'])) {
+		$uri = '?m=administration&p=watch_logger&search='.$_GET['search'].'&limit='.$l.'&page=';
+	} else {
+		$uri = '?m=administration&p=watch_logger&limit='.$l.'&page=';
 	}
 	echo paginationPages($count_logs[0]['total'], $p, $l, $uri, 3, 'watchLogger');
 }

--- a/modules/user_games/show_homes.php
+++ b/modules/user_games/show_homes.php
@@ -25,16 +25,19 @@
 function exec_ogp_module()
 {
 	global $db, $view, $loggedInUserInfo;
-	$search_field = (isset($_GET['search']) && !empty($_GET['search'])) ? $_GET['search'] : false;
 	
 	$page_GameHomes = (isset($_GET['page']) && (int)$_GET['page'] > 0) ? (int)$_GET['page'] : 1;
 	$limit_GameHomes = (isset($_GET['limit']) && (int)$_GET['limit'] > 0) ? (int)$_GET['limit'] : 10;
+
+	$searchString = (isset($_GET['search']) && !empty($_GET['search'])) ? $_GET['search'] : false;
+	$searchTypes = array('ip_port' => 'IP / Port', 'ownedBy' => 'Server Owner', 'rserver' => 'Remote Server', 'home_name' => 'Server Name');
+	$searchType = isset($_GET['searchType']) ? $_GET['searchType'] : false;
 	
 	if(hasValue($loggedInUserInfo) && is_array($loggedInUserInfo) && $loggedInUserInfo["users_page_limit"] && !hasValue($_GET['limit'])){
 		$limit_GameHomes = $loggedInUserInfo["users_page_limit"];
 	}
 
-	$game_homes = $db->getGameHomes_limit($page_GameHomes,$limit_GameHomes,$search_field);
+	$game_homes = $db->getGameHomes_limit($page_GameHomes, $limit_GameHomes, $searchType, $searchString);
 
 	echo "<h2>".get_lang('game_servers')."</h2>";
 	echo '<table style="width: 100%; margin-bottom: 50px;">
@@ -45,7 +48,8 @@ function exec_ogp_module()
 				<td style="width: 50%; vertical-align: middle; text-align: right;">
 					<form action="home.php" method="GET" style="float:right;">
 					<input type ="hidden" name="m" value="user_games" />
-					<input name="search" type="text" id="search" value="' . $search_field . '" />
+					'. create_drop_box_from_array($searchTypes, 'searchType', $searchType, false) .'
+					<input name="search" type="text" id="search" value="' . $searchString . '" />
 					<input type="submit" value="'.get_lang('search').'" />
 					</form>
 				</td>
@@ -97,14 +101,12 @@ function exec_ogp_module()
 	
 	echo "</table>";
 
-	$count_GameHomes = $db->get_GameHomes_count($search_field);
+	$count_GameHomes = $db->get_GameHomes_count($searchType, $searchString);
 	
-	if(isset($_GET['search']) && !empty($_GET['search'])){
-	$uri = '?m=user_games&search='.$_GET['search'].'&limit='.$limit_GameHomes.'&page=';
-	}
-	else
-	{
-	$uri = '?m=user_games&limit='.$limit_GameHomes.'&page=';
+	if (isset($_GET['search']) && !empty($_GET['search'])) {
+		$uri = '?m=user_games&search='.$_GET['search'].'&limit='.$limit_GameHomes.'&page=';
+	} else {
+		$uri = '?m=user_games&limit='.$limit_GameHomes.'&page=';
 	}
 	
 	echo paginationPages($count_GameHomes[0]['total'], $page_GameHomes, $limit_GameHomes, $uri, 3, 'userGames');


### PR DESCRIPTION
Along with 290bc70, removed the `ip` field in the WHERE clause to prevent an 'error: unknown field clause'

Added the ability for the user to define what they're searching in Administration -> Game Servers - as mentioned in #237
Check if the `$search_field` is empty in the watch_logger, otherwise if there's no logs, it was previously attempting a redirect loop.