### PR TITLE
Theme Include Consitency for Modules

### DIFF
--- a/includes/view.php
+++ b/includes/view.php
@@ -121,10 +121,18 @@ class OGPView {
 		$module = isset($_GET['m']) ? $_GET['m'] : "";
 		$subpage = isset($_GET['p']) ? $_GET['p'] : $module;
 		
-		if( file_exists( $path . MODULES . "$module/$subpage.css" ) ) 
-			$this->header_code .= "<link rel='stylesheet' href='" . $path . MODULES . "$module/$subpage.css'>" . "\n";
-		elseif( file_exists( MODULES . "$module/$subpage.css" ) )
-			$this->header_code .= "<link rel='stylesheet' href='" . MODULES . "$module/$subpage.css'>" . "\n";
+		$fc = array(
+			$path . MODULES . $module."/".$subpage.".css",
+			$path . MODULES . $module."/".$module.".css",
+			MODULES . $module."/".$subpage.".css",
+			MODULES . $module."/".$module.".css"
+		);
+		foreach($fc as $file_check){
+			if(file_exists($file_check)){
+				$this->header_code .= "<link rel='stylesheet' href='".$file_check."'>\n";
+				break;
+			}
+		}
 		
 		$module_name = isset($_GET['m']) ? get_lang($_GET['m']) : "";
 		$page_name = isset($_GET['p']) ? get_lang($_GET['p']) : "";
@@ -148,8 +156,15 @@ class OGPView {
 		// Include our global JS
 		$this->header_code .= '<script type="text/javascript" src="js/global.js"></script>' . "\n";
 
-		if (file_exists($path . MODULES . "$module/$subpage.js")) { 
-			$this->header_code .= '<script type="text/javascript" src="' . $path . MODULES . $module.'/'.$subpage.'.js"></script>' . "\n";
+		$fc = array(
+			$path . MODULES . $module."/".$subpage.".js",
+			$path . MODULES . $module."/".$module.".js"
+		);
+		foreach($fc as $file_check){
+			if(file_exists($file_check)){
+				$this->header_code .= "<script type='text/javascript' src='".$file_check."'></script>\n";
+				break;
+			}
 		}
 		
         $buffer = ob_get_contents();


### PR DESCRIPTION
Small Loop which checks Theme specific Files
A css or js File in Root Dir of a Module could be used for all Subpages instead of copy it.
Should not affect already exist Theme Files, because it works recursive backwards (see Array).