### PR TITLE
Sanitize some inline queries

### DIFF
--- a/lang/English/global.php
+++ b/lang/English/global.php
@@ -130,8 +130,6 @@ define('no_results_found', "No search results found for %s");
 define('tickets', "Support Tickets");
 define('news', "News");
 define('admin_news', "News Admin");
-define('rcon', "RCON");
-define('support', "Support");
 define('util', "Utilities");
 define('fast_download', "Fast Download");
 define('fd_user', "Fast Download");

--- a/modules/addonsmanager/addons_installer.php
+++ b/modules/addonsmanager/addons_installer.php
@@ -66,15 +66,26 @@ function exec_ogp_module() {
 	
 	$home_cfg_id = $home_info['home_cfg_id'];
 	$server_xml = read_server_config(SERVER_CONFIG_LOCATION."/".$home_info['home_cfg_file']);
+	
+	$addon_types = array('plugin', 'mappack', 'config');
 	$addon_type = isset($_REQUEST['addon_type']) ? $_REQUEST['addon_type'] : "";
+
     $state = isset($_REQUEST['state']) ? $_REQUEST['state'] : "";
     $pid = isset($_REQUEST['pid']) ? $_REQUEST['pid'] : -1;
 	
     if ( $state != "" )
     {
-        $addon_id = $_REQUEST['addon_id'];
+        $addon_id = (int)$_REQUEST['addon_id'];
+
 		$remote = new OGPRemoteLibrary($home_info['agent_ip'],$home_info['agent_port'],$home_info['encryption_key'],$home_info['timeout']);
 		$addons_rows = $db->resultQuery("SELECT url, path, post_script FROM OGP_DB_PREFIXaddons WHERE addon_id=".$addon_id);
+
+		if (!$addons_rows) {
+			print_failure(get_lang('invalid_addon'));
+			$view->refresh('?m=addonsmanager&p=user_addons&home_id='. $home_id .'&mod_id='. $mod_id .'&ip='. $ip .'&port='.$port);
+			return;
+		}
+
 		$addon_info = $addons_rows[0];
 		$url = $addon_info['url'];
 		$filename = basename($url);
@@ -213,6 +224,14 @@ function exec_ogp_module() {
     }
     elseif( $addon_type != "" )
     {
+
+    	if (!in_array($addon_type, $addon_types)) {
+    		print_failure(get_lang('invalid_addon_type'));
+    		$view->refresh('?m=addonsmanager&p=user_addons&home_id='. $home_id .'&mod_id='. $mod_id .'&ip='. $ip .'&port='.$port);
+
+    		return;
+    	}
+
 		?>
 			<h2><?php echo htmlentities($home_info['home_name'])."&nbsp;".get_lang($addon_type) ;?></h2>
             <table class='center'>

--- a/modules/addonsmanager/addons_manager.php
+++ b/modules/addonsmanager/addons_manager.php
@@ -1,1 +1,337 @@
-<script type="text/javascript" src="js/modules/addonsmanager.js"></script><?php/* * * OGP - Open Game Panel * Copyright (C) 2008 - 2017 The OGP Development Team * * http://www.opengamepanel.org/ * * This program is free software; you can redistribute it and/or * modify it under the terms of the GNU General Public License * as published by the Free Software Foundation; either version 2 * of the License, or any later version. * * This program is distributed in the hope that it will be useful, * but WITHOUT ANY WARRANTY; without even the implied warranty of * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the * GNU General Public License for more details. * * You should have received a copy of the GNU General Public License * along with this program; if not, write to the Free Software * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. * */function exec_ogp_module() {	global $db;		if (isset($_POST['create_addon']) AND isset($_POST['name']) AND $_POST['url']=="")	{		print_failure(get_lang("fill_the_url_address_to_a_compressed_file"));	}	elseif(isset($_POST['create_addon']) AND isset($_POST['url']) AND $_POST['name']=="")	{		print_failure(get_lang("fill_the_addon_name"));	}		elseif(isset($_POST['create_addon']) AND isset($_POST['name']) and isset($_POST['url']) and empty($_POST['addon_type']) )		{			print_failure(get_lang("select_an_addon_type"));	}	elseif(isset($_POST['create_addon']) AND isset($_POST['name']) and isset($_POST['url']) and isset($_POST['addon_type']) and empty($_POST['home_cfg_id']) )		{			print_failure(get_lang("select_a_game_type"));	}	elseif (isset($_POST['create_addon']) AND isset($_POST['name']) AND isset($_POST['url']) AND isset($_POST['addon_type']) and isset($_POST['home_cfg_id']) )	{			$fields['name'] = $_POST['name'];		$fields['url'] = $_POST['url'];		$fields['path'] = $_POST['path'];		$fields['addon_type'] = $_POST['addon_type'];		$fields['home_cfg_id'] = $_POST['home_cfg_id'];		$fields['post_script'] = $_POST['post_script'];		if( is_numeric($db->resultInsertId( 'addons', $fields )) )		{			print_success(get_lang_f("addon_has_been_created",$_POST['name']));			if (isset($_POST['addon_id']) && isset($_POST['edit']))				$db->query("DELETE FROM OGP_DB_PREFIXaddons WHERE addon_id=" . $_POST['addon_id']);		}	}	echo "<h2>".get_lang('addons_manager')."</h2>";	$name = isset($_POST['name']) ? $_POST['name'] : "";	$url = isset($_POST['url']) ? $_POST['url'] : "";	$path = isset($_POST['path']) ? $_POST['path'] : "";	$post_script = isset($_POST['post_script']) ? $_POST['post_script'] : "";	$home_cfg_id = isset($_POST['home_cfg_id']) ? $_POST['home_cfg_id'] : "";	$addon_type = isset($_POST['addon_type']) ? $_POST['addon_type'] : "";	if (isset($_POST['addon_id']) && isset($_POST['edit']))	{		$addons_rows = $db->resultQuery("SELECT * FROM OGP_DB_PREFIXaddons WHERE addon_id=".$_POST['addon_id']);		$addon_info = $addons_rows[0];		$name = isset($addon_info['name']) ? $addon_info['name'] : "";		$url = isset($addon_info['url']) ? $addon_info['url'] : "";		$path = isset($addon_info['path']) ? $addon_info['path'] : "";		$post_script = isset($addon_info['post_script']) ? $addon_info['post_script'] : "";		$home_cfg_id = isset($addon_info['home_cfg_id']) ? $addon_info['home_cfg_id'] : "";		$addon_type = isset($addon_info['addon_type']) ? $addon_info['addon_type'] : "";	}	?>	<form action="" method="post">		<table class="center">			<tr>								<td align="right">					<b><?php print_lang('addon_name'); ?></b>				</td>				<td align="left">					<input type="text" value="<?php echo $name; ?>" name="name" size="85" title="<?php print_lang('addon_name_info'); ?>" />				</td>			</tr>			<tr>									<td align="right">					<b><?php print_lang('url'); ?></b>				</td>				<td align="left">					<input type="text" value="<?php echo $url; ?>" name="url" size="85" title="<?php print_lang('url_info'); ?>" />				</td>			</tr>			<!-- If any, you can set the destination path, should be a relative path to the main game server folder. -->			<tr>									<td align="right">					<b><?php print_lang('path'); ?></b>					</td>					<td align="left">					<input type="text" value="<?php echo $path; ?>" name="path" size="85" title="<?php print_lang('path_info'); ?>" />				</td>			</tr>			<tr>									<td align="right">					<b><?php print_lang('post-script'); ?></b><br>					<u><?php print_lang('replacements'); ?></u><br>					%home_path%<br>					%home_name%<br>					%control_password%<br>					%max_players%<br>					%ip%<br>					%port%<br>					%query_port%<br>					%incremental%<br>				</td>				<td align="left">					<textarea name="post_script" style="width:99%;height:175px;" title="<?php print_lang('post-script_info'); ?>" ><?php echo strip_real_escape_string($post_script); ?></textarea>				</td>			</tr>			<tr>				<td align="right">					<b><?php print_lang('select_game_type'); ?></b>				</td>				<td align="left">				<select name='home_cfg_id'>		<?php		$game_cfgs = $db->getGameCfgs();		echo "<option style='background:black;color:white;' value=''>".get_lang('linux_games')."</option>\n";				foreach ( $game_cfgs as $row )		{			if ( preg_match("/linux/", $row['game_key']) )			{				$selected = (isset($home_cfg_id) AND $row['home_cfg_id'] == $home_cfg_id) ? 'selected="selected"' : '';				echo "<option $selected value='".$row['home_cfg_id']."'>".$row['game_name'];				if  ( preg_match("/64/", $row['game_key']) ) echo " (64bit)";				echo "</option>\n";			}		}		echo "<option style='background:black;color:white;' value=''>".get_lang('windows_games')."</option>\n";		foreach ( $game_cfgs as $row )		{			if ( preg_match("/win/", $row['game_key']) )			{				$selected = (isset($home_cfg_id) AND $row['home_cfg_id'] == $home_cfg_id) ? 'selected=selected' : '';				echo "<option $selected value='".$row['home_cfg_id']."'>".$row['game_name'];				if  ( preg_match("/64/", $row['game_key']) ) echo " (64bit)";				echo "</option>\n";			}		}		?>				</select>				</td>			</tr>			<tr>				<td align="right">				<b><?php print_lang('type'); ?></b>					</td>				<td align="left">		<?php		$types = array( 'plugin', 'mappack', 'config' );		foreach($types as $type)		{			$checked = ( isset($addon_type) AND $type == $addon_type) ? 'checked' : '';			echo '<input type="radio" name="addon_type" value="'.$type.'" '.$checked.'>'.get_lang($type);		}		?>				</td>			</tr>			<tr>				<td colspan="2" align="center">				<?php 				if (isset($_POST['addon_id']) && isset($_POST['edit']))				{					echo '<input type="hidden" name="addon_id" value="'.$_POST['addon_id'].'" >';					echo '<input type="hidden" name="edit" value="'.$_POST['edit'].'" >';					?>					<button name="create_addon" type="submit">					<?php print_lang('edit_addon'); ?>					</button>				<?php				}				else				{				?>					<button name="create_addon" type="submit">					<?php print_lang('create_addon'); ?>					</button>				<?php				}				?>				</td>			</tr>		</table>	</form>	<br>	<h2><?php print_lang('addons_db'); ?></h2>	<table class="center">		<tr>				<td align="center">				<form name="remove" action="" method="get">				<input name="m" type="hidden" value="addonsmanager"/>				<input name="p" type="hidden" value="addons_manager"/>				<b><?php print_lang('game'); ?></b> <select name='home_cfg_id'>				<?php				echo "<option style='background:black;color:white;' value=''>".get_lang('linux_games')."</option>\n";				foreach ( $game_cfgs as $row )				{					if ( preg_match("/linux/", $row['game_key']) )					{						if(isset($_GET['home_cfg_id']) AND $row['home_cfg_id'] == $_GET['home_cfg_id']) 							$selected = "selected='selected'";						else							$selected = "";						echo "<option value='".$row['home_cfg_id']."' $selected >".$row['game_name'];						if  ( preg_match("/64/", $row['game_key']) ) echo " (64bit)";						echo "</option>\n";					}				}				echo "<option style='background:black;color:white;' value=''>".get_lang('windows_games')."</option>\n";				foreach ( $game_cfgs as $row )				{						if(isset($_GET['home_cfg_id']) AND $row['home_cfg_id'] == $_GET['home_cfg_id']) 							$selected = "selected='selected'";						else							$selected = "";					if ( preg_match("/win/", $row['game_key']) )					{						echo "<option value='".$row['home_cfg_id']."' $selected >".$row['game_name'];						if  ( preg_match("/64/", $row['game_key']) ) echo " (64bit)";						echo "</option>\n";					}				}								?>				</select>				<b><?php print_lang('type'); ?></b> <select name="addon_type">				<option <?php if (isset($_GET['addon_type']) AND $_GET['addon_type']=="plugin" ) echo "selected='selected'";?> value="plugin"><?php print_lang('plugin'); ?></option>				<option <?php if (isset($_GET['addon_type']) AND $_GET['addon_type']=="mappack" ) echo "selected='selected'";?> value="mappack"><?php print_lang('mappack'); ?></option>				<option <?php if (isset($_GET['addon_type']) AND $_GET['addon_type']=="config" ) echo "selected='selected'";?> value="config"><?php print_lang('config'); ?></option>						<select/>							<button name="show" type="submit">				<?php print_lang('show'); ?>				</button>			</td>		</tr>		<tr>			<td>				<input name="show_game" type="submit" value="<?php print_lang('show_addons_for_selected_game'); ?>"/>				<input name="show_type" type="submit" value="<?php print_lang('show_addons_for_selected_type'); ?>"/>				<input name="show_all" type="submit" value="<?php print_lang('show_all_addons'); ?>"/>			</td>		</tr>	</form>	</table>	<?php 	if (isset($_POST['addon_id']) && isset($_POST['remove']))	{		if (!$db->query("DELETE FROM OGP_DB_PREFIXaddons WHERE addon_id=" . $_POST['addon_id']))			print_lang('can_not_remove_addon');	}		$home_cfg_id = !empty($_GET['home_cfg_id']) ? $_GET['home_cfg_id'] : 0;	$addon_type = !empty($_GET['addon_type']) ? $_GET['addon_type'] : "";	if ( isset($_GET['show']) )	{		$result = $db->resultQuery("SELECT DISTINCT addon_id, name, game_name, url, path FROM OGP_DB_PREFIXaddons NATURAL JOIN OGP_DB_PREFIXconfig_homes WHERE addon_type='".$addon_type."' AND home_cfg_id=".$home_cfg_id);	}	elseif ( isset($_GET['show_all']) )	{		$result = $db->resultQuery("SELECT DISTINCT addon_id, name, game_name, url, path FROM OGP_DB_PREFIXaddons NATURAL JOIN OGP_DB_PREFIXconfig_homes");	}	elseif ( isset($_GET['show_type']))	{		unset($_GET['show_all']);		unset($_GET['show_game']);		$result = $db->resultQuery("SELECT DISTINCT addon_id, name, game_name, url, path FROM OGP_DB_PREFIXaddons NATURAL JOIN OGP_DB_PREFIXconfig_homes WHERE addon_type='".$_GET['addon_type']."'");	}	elseif ( isset($_GET['show_game']))	{		unset($_GET['show_all']);		unset($_GET['show_type']);		$result = $db->resultQuery("SELECT DISTINCT addon_id, name, game_name, url, path FROM OGP_DB_PREFIXaddons NATURAL JOIN OGP_DB_PREFIXconfig_homes WHERE home_cfg_id=".$home_cfg_id);	}	?>		<table class="center">	<?php	if (isset($result) and $result > 0)	{		foreach($result as $row)		{		?>		<tr>		<form action="" method="post">		 <td class='left'>		  <b><?php echo $row['game_name']; ?></b>		 </td>		 <td>		  <?php echo $row['name'];?>		 </td>		 <td>		  <input name="addon_id" type="hidden" value="<?php echo $row['addon_id'];?>"/>		  <input name="edit" type="submit" value="<?php print_lang('edit_addon'); ?>"/>		  <input name="remove" type="submit" value="<?php print_lang('remove_addon'); ?>"/>		 </td>		</form>		</tr>		<?php		}	}	?>	</table>	<?php}?>
+<script type="text/javascript" src="js/modules/addonsmanager.js"></script>
+<?php
+/*
+ *
+ * OGP - Open Game Panel
+ * Copyright (C) 2008 - 2017 The OGP Development Team
+ *
+ * http://www.opengamepanel.org/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+function exec_ogp_module() {
+
+	global $db;
+	
+	if (isset($_POST['create_addon']) AND isset($_POST['name']) AND $_POST['url']=="")
+	{
+		print_failure(get_lang("fill_the_url_address_to_a_compressed_file"));
+	}
+	elseif(isset($_POST['create_addon']) AND isset($_POST['url']) AND $_POST['name']=="")
+	{
+		print_failure(get_lang("fill_the_addon_name"));
+	}	
+	elseif(isset($_POST['create_addon']) AND isset($_POST['name']) and isset($_POST['url']) and empty($_POST['addon_type']) )	
+	{	
+		print_failure(get_lang("select_an_addon_type"));
+	}
+	elseif(isset($_POST['create_addon']) AND isset($_POST['name']) and isset($_POST['url']) and isset($_POST['addon_type']) and empty($_POST['home_cfg_id']) )	
+	{	
+		print_failure(get_lang("select_a_game_type"));
+	}
+	elseif (isset($_POST['create_addon']) AND isset($_POST['name']) AND isset($_POST['url']) AND isset($_POST['addon_type']) and isset($_POST['home_cfg_id']) )
+	{	
+		$fields['name'] = $_POST['name'];
+		$fields['url'] = $_POST['url'];
+		$fields['path'] = $_POST['path'];
+		$fields['addon_type'] = $_POST['addon_type'];
+		$fields['home_cfg_id'] = $_POST['home_cfg_id'];
+		$fields['post_script'] = $_POST['post_script'];
+		if( is_numeric($db->resultInsertId( 'addons', $fields )) )
+		{
+			print_success(get_lang_f("addon_has_been_created",$_POST['name']));
+			if (isset($_POST['addon_id']) && (int)$_POST['addon_id'] > 0 && isset($_POST['edit']))
+				$db->query("DELETE FROM OGP_DB_PREFIXaddons WHERE addon_id=" . (int)$_POST['addon_id']);
+		}
+	}
+
+	echo "<h2>".get_lang('addons_manager')."</h2>";
+	$name = isset($_POST['name']) ? $_POST['name'] : "";
+	$url = isset($_POST['url']) ? $_POST['url'] : "";
+	$path = isset($_POST['path']) ? $_POST['path'] : "";
+	$post_script = isset($_POST['post_script']) ? $_POST['post_script'] : "";
+	$home_cfg_id = isset($_POST['home_cfg_id']) ? $_POST['home_cfg_id'] : "";
+	$addon_type = isset($_POST['addon_type']) ? $_POST['addon_type'] : "";
+	$addon_types = array('plugin', 'mappack', 'config');
+
+	if (isset($_POST['addon_id']) && (int)$_POST['addon_id'] > 0 && isset($_POST['edit']))
+	{
+		$addons_rows = $db->resultQuery("SELECT * FROM OGP_DB_PREFIXaddons WHERE addon_id=".(int)$_POST['addon_id']);
+		$addon_info = $addons_rows[0];
+		$name = isset($addon_info['name']) ? $addon_info['name'] : "";
+		$url = isset($addon_info['url']) ? $addon_info['url'] : "";
+		$path = isset($addon_info['path']) ? $addon_info['path'] : "";
+		$post_script = isset($addon_info['post_script']) ? $addon_info['post_script'] : "";
+		$home_cfg_id = isset($addon_info['home_cfg_id']) ? $addon_info['home_cfg_id'] : "";
+		$addon_type = isset($addon_info['addon_type']) ? $addon_info['addon_type'] : "";
+	}
+	?>
+	<form action="" method="post">
+		<table class="center">
+			<tr>				
+				<td align="right">
+					<b><?php print_lang('addon_name'); ?></b>
+				</td>
+				<td align="left">
+					<input type="text" value="<?php echo $name; ?>" name="name" size="85" title="<?php print_lang('addon_name_info'); ?>" />
+				</td>
+			</tr>
+			<tr>					
+				<td align="right">
+					<b><?php print_lang('url'); ?></b>
+				</td>
+				<td align="left">
+					<input type="text" value="<?php echo $url; ?>" name="url" size="85" title="<?php print_lang('url_info'); ?>" />
+				</td>
+			</tr>
+			<!-- If any, you can set the destination path, should be a relative path to the main game server folder. -->
+			<tr>					
+				<td align="right">
+					<b><?php print_lang('path'); ?></b>
+					</td>
+					<td align="left">
+					<input type="text" value="<?php echo $path; ?>" name="path" size="85" title="<?php print_lang('path_info'); ?>" />
+				</td>
+			</tr>
+			<tr>					
+				<td align="right">
+					<b><?php print_lang('post-script'); ?></b><br>
+					<u><?php print_lang('replacements'); ?></u><br>
+					%home_path%<br>
+					%home_name%<br>
+					%control_password%<br>
+					%max_players%<br>
+					%ip%<br>
+					%port%<br>
+					%query_port%<br>
+					%incremental%<br>
+				</td>
+				<td align="left">
+					<textarea name="post_script" style="width:99%;height:175px;" title="<?php print_lang('post-script_info'); ?>" ><?php echo strip_real_escape_string($post_script); ?></textarea>
+				</td>
+			</tr>
+			<tr>
+				<td align="right">
+					<b><?php print_lang('select_game_type'); ?></b>
+				</td>
+				<td align="left">
+				<select name='home_cfg_id'>
+		<?php
+		$game_cfgs = $db->getGameCfgs();
+		echo "<option style='background:black;color:white;' value=''>".get_lang('linux_games')."</option>\n";
+		
+		foreach ( $game_cfgs as $row )
+		{
+			if ( preg_match("/linux/", $row['game_key']) )
+			{
+				$selected = (isset($home_cfg_id) AND $row['home_cfg_id'] == $home_cfg_id) ? 'selected="selected"' : '';
+				echo "<option $selected value='".$row['home_cfg_id']."'>".$row['game_name'];
+				if  ( preg_match("/64/", $row['game_key']) ) echo " (64bit)";
+				echo "</option>\n";
+			}
+		}
+		echo "<option style='background:black;color:white;' value=''>".get_lang('windows_games')."</option>\n";
+		foreach ( $game_cfgs as $row )
+		{
+			if ( preg_match("/win/", $row['game_key']) )
+			{
+				$selected = (isset($home_cfg_id) AND $row['home_cfg_id'] == $home_cfg_id) ? 'selected=selected' : '';
+				echo "<option $selected value='".$row['home_cfg_id']."'>".$row['game_name'];
+				if  ( preg_match("/64/", $row['game_key']) ) echo " (64bit)";
+				echo "</option>\n";
+			}
+		}
+		?>
+				</select>
+				</td>
+			</tr>
+			<tr>
+				<td align="right">
+				<b><?php print_lang('type'); ?></b>	
+				</td>
+				<td align="left">
+		<?php
+		$types = array( 'plugin', 'mappack', 'config' );
+		foreach($types as $type)
+		{
+			$checked = ( isset($addon_type) AND $type == $addon_type) ? 'checked' : '';
+			echo '<input type="radio" name="addon_type" value="'.$type.'" '.$checked.'>'.get_lang($type);
+		}
+		?>
+				</td>
+			</tr>
+			<tr>
+				<td colspan="2" align="center">
+				<?php 
+				if (isset($_POST['addon_id']) && isset($_POST['edit']))
+				{
+					echo '<input type="hidden" name="addon_id" value="'.$_POST['addon_id'].'" >';
+					echo '<input type="hidden" name="edit" value="'.$_POST['edit'].'" >';
+					?>
+					<button name="create_addon" type="submit">
+					<?php print_lang('edit_addon'); ?>
+					</button>
+				<?php
+				}
+				else
+				{
+				?>
+					<button name="create_addon" type="submit">
+					<?php print_lang('create_addon'); ?>
+					</button>
+				<?php
+				}
+				?>
+				</td>
+			</tr>
+		</table>
+	</form>
+	<br>
+	<h2><?php print_lang('addons_db'); ?></h2>
+	<table class="center">
+		<tr>	
+			<td align="center">
+				<form name="remove" action="" method="get">
+				<input name="m" type="hidden" value="addonsmanager"/>
+				<input name="p" type="hidden" value="addons_manager"/>
+				<b><?php print_lang('game'); ?></b> <select name='home_cfg_id'>
+				<?php
+				echo "<option style='background:black;color:white;' value=''>".get_lang('linux_games')."</option>\n";
+				foreach ( $game_cfgs as $row )
+				{
+					if ( preg_match("/linux/", $row['game_key']) )
+					{
+						if(isset($_GET['home_cfg_id']) AND $row['home_cfg_id'] == $_GET['home_cfg_id']) 
+							$selected = "selected='selected'";
+						else
+							$selected = "";
+						echo "<option value='".$row['home_cfg_id']."' $selected >".$row['game_name'];
+						if  ( preg_match("/64/", $row['game_key']) ) echo " (64bit)";
+						echo "</option>\n";
+					}
+				}
+				echo "<option style='background:black;color:white;' value=''>".get_lang('windows_games')."</option>\n";
+				foreach ( $game_cfgs as $row )
+				{
+						if(isset($_GET['home_cfg_id']) AND $row['home_cfg_id'] == $_GET['home_cfg_id']) 
+							$selected = "selected='selected'";
+						else
+							$selected = "";
+					if ( preg_match("/win/", $row['game_key']) )
+					{
+						echo "<option value='".$row['home_cfg_id']."' $selected >".$row['game_name'];
+						if  ( preg_match("/64/", $row['game_key']) ) echo " (64bit)";
+						echo "</option>\n";
+					}
+				}
+				
+				?>
+				</select>
+				<b><?php print_lang('type'); ?></b>
+				<select name="addon_type">
+				<?php
+					$option = '';
+
+					foreach ($addon_types as $k) {
+						$option .= '<option';
+
+						if (isset($_GET['addon_type']) && $_GET['addon_type'] == $k) {
+							$option .= ' selected';
+						}
+
+						$option .= ' value="'. $k .'">'.get_lang($k).'</option>';
+					}
+
+					echo $option;
+				?>
+		
+				</select>			
+				<button name="show" type="submit">
+				<?php print_lang('show'); ?>
+				</button>
+			</td>
+		</tr>
+		<tr>
+			<td>
+				<input name="show_game" type="submit" value="<?php print_lang('show_addons_for_selected_game'); ?>"/>
+				<input name="show_type" type="submit" value="<?php print_lang('show_addons_for_selected_type'); ?>"/>
+				<input name="show_all" type="submit" value="<?php print_lang('show_all_addons'); ?>"/>
+			</td>
+		</tr>
+	</form>
+	</table>
+	<?php 
+	if (isset($_POST['addon_id']) && (int)$_POST['addon_id'] > 0 && isset($_POST['remove']))
+	{
+		if (!$db->query("DELETE FROM OGP_DB_PREFIXaddons WHERE addon_id=" . (int)$_POST['addon_id']))
+			print_lang('can_not_remove_addon');
+	}
+	
+	$home_cfg_id = !empty($_GET['home_cfg_id']) && (int)$_GET['home_cfg_id'] > 0 ? (int)$_GET['home_cfg_id'] : 0;
+	$addon_type = !empty($_GET['addon_type']) && in_array($_GET['addon_type'], $addon_types) ? $_GET['addon_type'] : "";
+
+	if ( isset($_GET['show']) )
+	{
+		$result = $db->resultQuery("SELECT DISTINCT addon_id, name, game_name, url, path FROM OGP_DB_PREFIXaddons NATURAL JOIN OGP_DB_PREFIXconfig_homes WHERE addon_type='".$addon_type."' AND home_cfg_id=".$home_cfg_id);
+	}
+	elseif ( isset($_GET['show_all']) )
+	{
+		$result = $db->resultQuery("SELECT DISTINCT addon_id, name, game_name, url, path FROM OGP_DB_PREFIXaddons NATURAL JOIN OGP_DB_PREFIXconfig_homes");
+	}
+	elseif ( isset($_GET['show_type']))
+	{
+		unset($_GET['show_all']);
+		unset($_GET['show_game']);
+		$result = $db->resultQuery("SELECT DISTINCT addon_id, name, game_name, url, path FROM OGP_DB_PREFIXaddons NATURAL JOIN OGP_DB_PREFIXconfig_homes WHERE addon_type='".$addon_type."'");
+	}
+	elseif ( isset($_GET['show_game']))
+	{
+		unset($_GET['show_all']);
+		unset($_GET['show_type']);
+		$result = $db->resultQuery("SELECT DISTINCT addon_id, name, game_name, url, path FROM OGP_DB_PREFIXaddons NATURAL JOIN OGP_DB_PREFIXconfig_homes WHERE home_cfg_id=".$home_cfg_id);
+	}
+	?>	
+	<table class="center">
+	<?php
+	if (isset($result) and $result > 0)
+	{
+		foreach($result as $row)
+		{
+		?>
+		<tr>
+		<form action="" method="post">
+		 <td class='left'>
+		  <b><?php echo $row['game_name']; ?></b>
+		 </td>
+		 <td>
+		  <?php echo $row['name'];?>
+		 </td>
+		 <td>
+		  <input name="addon_id" type="hidden" value="<?php echo $row['addon_id'];?>"/>
+		  <input name="edit" type="submit" value="<?php print_lang('edit_addon'); ?>"/>
+		  <input name="remove" type="submit" value="<?php print_lang('remove_addon'); ?>"/>
+		 </td>
+		</form>
+		</tr>
+		<?php
+		}
+	}
+	?>
+	</table>
+	<?php
+}
+?>

--- a/modules/administration/banlist.php
+++ b/modules/administration/banlist.php
@@ -33,6 +33,7 @@ function exec_ogp_module()
 		unset($_POST['unban']);
 		foreach($_POST as $name => $ip)
 		{
+			$ip = $db->real_escape_string($ip);
 			$db->query("UPDATE `OGP_DB_PREFIXban_list` SET logging_attempts='0', banned_until='0' WHERE client_ip = '$ip';");
 		}
 	}

--- a/modules/dashboard/updateWidgets.php
+++ b/modules/dashboard/updateWidgets.php
@@ -39,12 +39,15 @@ function exec_ogp_module()
 	foreach($data->items as $item)  
 	{  
 		//Extract column number for panel  
-		$col_id=preg_replace('/[^\d\s]/', '', $item->column);  
+		$col_id = preg_replace('/[^\d\s]/', '', $item->column);
 		//Extract id of the panel  
-		$widget_id=preg_replace('/[^\d\s]/', '', $item->id);  
-		$db->query("UPDATE ".OGP_DB_PREFIX."widgets_users SET column_id='$col_id', sort_no='".$item->order."', collapsed='".$item->collapsed."' WHERE widget_id='".$widget_id."' AND user_id='".$_SESSION['user_id']."'") or   
-		die($db->getError());
-	}  
+		$widget_id = preg_replace('/[^\d\s]/', '', $item->id);
+
+		if (is_numeric($col_id) && is_numeric($widget_id)) {
+			$db->query("UPDATE ".OGP_DB_PREFIX."widgets_users SET column_id='$col_id', sort_no='".(int)$item->order."', collapsed='".(int)$item->collapsed."' WHERE widget_id='".$widget_id."' AND user_id='".$_SESSION['user_id']."'");
+		}
+	}
+
 	echo "success";
 }
 ?>

--- a/modules/update/blacklist.php
+++ b/modules/update/blacklist.php
@@ -82,14 +82,17 @@ function exec_ogp_module()
 	{
 		foreach($_POST['blacklist'] as $file)
 		{
+			$file = $db->real_escape_string($file);
 			$db->query("INSERT INTO `OGP_DB_PREFIXupdate_blacklist` SET file_path='$file';");
 		}
+		
 		foreach($_POST['folder_files'] as $file)
 		{
 			if(in_array($file,$current_blacklist))
 			{
 				if(!in_array($file,$_POST['blacklist']))
 				{
+					$file = $db->real_escape_string($file);
 					$db->query("DELETE FROM `OGP_DB_PREFIXupdate_blacklist` WHERE file_path='$file';");
 				}
 			}

--- a/modules/update/updating.php
+++ b/modules/update/updating.php
@@ -244,8 +244,9 @@ function exec_ogp_module()
 				}
 				
 				// update version info in db
-								
-				$db->query("UPDATE OGP_DB_PREFIXsettings SET value = '$_GET[version]' WHERE setting = 'ogp_version'");
+
+				$version = $db->real_escape_string($_GET['version']);
+				$db->query("UPDATE OGP_DB_PREFIXsettings SET value = '$version' WHERE setting = 'ogp_version'");
 				$db->query("UPDATE OGP_DB_PREFIXsettings SET value = '$vtype' WHERE setting = 'version_type'");
 
 				// Remove the downloaded package

--- a/modules/user_games/edit_home.php
+++ b/modules/user_games/edit_home.php
@@ -803,7 +803,7 @@ function exec_ogp_module()
 			{
 				if( isset($_REQUEST['set_ip']) )
 				{
-					$ip_id = $_POST['ip'];
+					$ip_id = $db->real_escape_string($_POST['ip']);
 					$ip_row = $db->resultQuery( "SELECT ip FROM OGP_DB_PREFIXremote_server_ips WHERE ip_id=".$ip_id );
 					$ip = $ip_row['0']['ip'];
 					$port = $_POST['port'];

--- a/modules/user_games/install_cmds.php
+++ b/modules/user_games/install_cmds.php
@@ -39,7 +39,7 @@ function exec_ogp_module()
 
 		if(isset($_POST['edit_preinstall_cmds']))
 		{
-			$precmd = $_POST['edit_preinstall_cmds'];
+			$precmd = $db->real_escape_string($_POST['edit_preinstall_cmds']);
 			if( isset( $_POST['save_as_default'] ) )
 			{
 				$game_mod_query = "UPDATE OGP_DB_PREFIXconfig_mods SET def_precmd='$precmd' WHERE mod_cfg_id='$mod_cfg_id'";
@@ -55,7 +55,7 @@ function exec_ogp_module()
 
 		if(isset($_POST['edit_postinstall_cmds']))
 		{
-			$postcmd = $_POST['edit_postinstall_cmds'];
+			$postcmd = $db->real_escape_string($_POST['edit_postinstall_cmds']);
 			if( isset( $_POST['save_as_default'] ) )
 			{
 				$game_mod_query = "UPDATE OGP_DB_PREFIXconfig_mods SET def_postcmd='$postcmd' WHERE mod_cfg_id='$mod_cfg_id'";

--- a/protocol/TeamSpeak3/functions.php
+++ b/protocol/TeamSpeak3/functions.php
@@ -43,13 +43,15 @@ try
 	{
 		$status = "online";
 		$startup_file_exists = $remote->rfile_exists( "startups/".$server_home['ip']."-".$server_home['port'] ) === 1;
-		if(isset($_POST['new_ts3_port']) AND $server_home['home_id'] == $_POST['home_id'] )
-		{
-			if(isset($ts3_ServerInstance)) unset($ts3_ServerInstance);
+
+		if (isset($_POST['new_ts3_port']) && isPortValid($_POST['new_ts3_port']) && $server_home['home_id'] == $_POST['home_id']) {
+			if (isset($ts3_ServerInstance)) unset($ts3_ServerInstance);
+
 			$ts3_ServerInstance = TeamSpeak3::factory("serverquery://" . $cfg["user"] . ":" . $cfg["pass"] . "@" . $cfg["host"] . ":" . $cfg["query"] . "/");
 			$new_port = $_POST['new_ts3_port'];
 			$new_hostname = $_POST['new_ts3_hostname'];
 			$new_players = $_POST['new_ts3_players'];
+
 			/* add port to home on ogp db */
 			$AddVirtual = $db->addGameIpPort($server_home['home_id'], $server_home['ip_id'], $new_port);
 			if ($AddVirtual === TRUE)
@@ -94,10 +96,14 @@ try
 					$ts3_ServerInstance = TeamSpeak3::factory("serverquery://" . $cfg["user"] . ":" . $cfg["pass"] . "@" . $cfg["host"] . ":" . $cfg["query"] . "/");
 												
 					/* stop & remove server using given ID */
-					$sid =  $_POST['id'];
-					$ts3_ServerInstance->serverStop($sid);
-					$ts3_ServerInstance->serverDelete($sid);
-					$db->query( "DELETE FROM OGP_DB_PREFIXts3_homes WHERE vserver_id=" . $sid );
+					$sid = (int)$_POST['id'];
+
+					if ($sid !== 0) {
+						$ts3_ServerInstance->serverStop($sid);
+						$ts3_ServerInstance->serverDelete($sid);
+						$db->query( "DELETE FROM OGP_DB_PREFIXts3_homes WHERE vserver_id=" . $db->real_escape_string($sid));
+					}
+
 					/* refresh */
 					$view->refresh("?m=gamemanager&p=game_monitor&home_id=" . $server_home['home_id'], 0);
 				}
@@ -140,14 +146,14 @@ try
 		$TS3Admin_installed = $db->isModuleInstalled('TS3Admin');
 		if( $TS3Admin_installed )
 		{
-			if(isset($_POST['assign_to_user']) && $_POST['vserver_id'] == $ts3_ServerInstance->getId() AND $server_home['remote_server_id'] == $_POST['remote_server_id'] )
+			if(isset($_POST['assign_to_user']) && (int)$_POST['vserver_id'] == $ts3_ServerInstance->getId() AND $server_home['remote_server_id'] == $_POST['remote_server_id'] )
 			{
 				$query_ip = $server_home['use_nat'] == 1 ? $server_home['agent_ip'] : $server_home['ip'];
-				$db->query("INSERT INTO OGP_DB_PREFIXts3_homes (`rserver_id`, `ip`, `pwd`, `vserver_id`, `user_id`, `port`) VALUES ('".$server_home['remote_server_id']."', '".$query_ip."', '".$cfg["pass"]."', '".$_POST['vserver_id']."', '".$_POST['assign_to_user']."', '".$cfg['query']."');");
+				$db->query("INSERT INTO OGP_DB_PREFIXts3_homes (`rserver_id`, `ip`, `pwd`, `vserver_id`, `user_id`, `port`) VALUES ('".$server_home['remote_server_id']."', '".$query_ip."', '".$cfg["pass"]."', '".(int)$_POST['vserver_id']."', '".$db->real_escape_string($_POST['assign_to_user'])."', '".$cfg['query']."');");
 			}
-			if(isset($_POST['remove_vuser_id']) && $_POST['vserver_id'] == $ts3_ServerInstance->getId() AND $server_home['remote_server_id'] == $_POST['remote_server_id'] )
+			if(isset($_POST['remove_vuser_id']) && (int)$_POST['vserver_id'] == $ts3_ServerInstance->getId() AND $server_home['remote_server_id'] == (int)$_POST['remote_server_id'] )
 			{
-				$db->query( "DELETE FROM OGP_DB_PREFIXts3_homes WHERE vserver_id='" . $_POST['vserver_id'] . "' AND user_id='".$_POST['remove_vuser_id']."' AND rserver_id='".$_POST['remote_server_id']."';" );
+				$db->query( "DELETE FROM OGP_DB_PREFIXts3_homes WHERE vserver_id='" . (int)$_POST['vserver_id'] . "' AND user_id='".(int)$_POST['remove_vuser_id']."' AND rserver_id='".(int)$_POST['remote_server_id']."';" );
 			}
 			$add_remove_virtual .= "<tr><td>Assign This Virtual<br>Server To User</td><td>
 									<form action='' method='POST'>


### PR DESCRIPTION
With the large change to the database_mysqli.php file (#285) which removed escaping on every `_POST`, `_GET` and `_REQUEST` variable due to some double escaping, there was some in-line queries ran which were now vulnerable.

The change to English/global.php is because the constants are already defined.

`addonsmanager/addons_manager.php` appears as a large diff, I believe that's because of the line endings on the current version on Github - see: https://github.com/OpenGamePanel/OGP-Website/blob/master/modules/addonsmanager/addons_manager.php

