### PR TITLE
Update DayZ config to not use hardcoded values for mods and fix multi-instance config + Arma 3 64 bit template

### DIFF
--- a/modules/config_games/server_configs/arma3_win64.xml
+++ b/modules/config_games/server_configs/arma3_win64.xml
@@ -1,0 +1,50 @@
+<game_config>
+  <game_key>arma3_win64</game_key>
+  <protocol>lgsl</protocol>
+  <lgsl_query_name>arma3</lgsl_query_name>
+  <installer>steamcmd</installer>
+  <game_name>Arma 3</game_name>
+  <server_exec_name>arma3server_x64.exe</server_exec_name>
+  <cli_template>-config=server.cfg -cfg=basic.cfg -profiles=profile %MEMORY% %PORT% %PLAYERS%</cli_template>
+  <cli_params>
+   <cli_param cli_string="-port=" id="PORT"/>
+   <cli_param cli_string="-maxplayers=" id="PLAYERS"/>
+  </cli_params>
+  <cli_allow_chars>;</cli_allow_chars> <!-- escaped by default: \ " ' | & ; > < ` $ ( ) [ ] -->
+  <console_log>profile/server_console.log</console_log>
+  <max_user_amount>64</max_user_amount>
+  <mods>
+   <mod key='Arma3'>
+    <name>none</name>
+    <installer_name>233780</installer_name>
+   </mod>
+  </mods>
+  <replace_texts>
+   <text key="home_name">
+    <default>(hostname\s*=\s*")(.*)(";)</default>
+    <var>hostname = "%key%";</var>
+    <filepath>server.cfg</filepath>
+    <options>key-regex</options>
+   </text>
+   <text key="max_players">
+    <default>(maxPlayers\s*=\s*)(.*)(;)</default>
+    <var>maxPlayers = %key%;</var>
+    <filepath>server.cfg</filepath>
+    <options>key-regex</options>
+   </text>
+   <text key="control_password">
+    <default>(passwordAdmin\s*=\s*")(.*)(";)</default>
+    <var>passwordAdmin = "%key%";</var>
+    <filepath>server.cfg</filepath>
+    <options>key-regex</options>
+   </text>
+  </replace_texts>
+  <server_params>
+   <param id="MEMORY" key="-maxMem=" type="text">
+    <option>ns</option>
+    <default>1024</default>
+    <caption>Max RAM allocated</caption>
+    <desc>Maximum usable memory in MB, for example: 1024</desc>
+   </param>
+  </server_params>
+</game_config>

--- a/modules/config_games/server_configs/dayz_arma2oa_win32.xml
+++ b/modules/config_games/server_configs/dayz_arma2oa_win32.xml
@@ -4,7 +4,7 @@
  <lgsl_query_name>dayzmod</lgsl_query_name>
  <game_name>DayZ Mod (OA)</game_name>
  <server_exec_name>arma2oaserver.exe</server_exec_name>
- <cli_template>%MEMORY% %PORT% %PLAYERS% "-config=profile\server.cfg" "-cfg=profile\basic.cfg" -profiles=profile -noSound -noPause</cli_template>
+ <cli_template>%MEMORY% %PORT% %PLAYERS% "-config=profile\server.cfg" "-cfg=profile\basic.cfg" -profiles=profile -noSound</cli_template>
  <cli_params>
    <cli_param cli_string="-port=" id="PORT"/>
    <cli_param id="PLAYERS" cli_string="-maxplayers=" />
@@ -67,15 +67,14 @@
    <caption>Max RAM allocated</caption>
    <desc>Maximum usable memory in MB, for example: 1024</desc>
   </param>
-  <param key="-mod=" type="select">
-    <option value="@DayZ;@Hive;">Vanilla</option>
-    <option value="@DayZ_Epoch;@DayZ_Epoch_Server;">Epoch</option>
-    <option value="@DayZOverwatch;@DayZ_Epoch;@DayZ_Epoch_Server;">Overpoch</option>
-    <option value="@DayZOrigins;@DayZ_Epoch;@DayZ_Epoch_Server;">Origins</option>
-    <option value="@DayZOverwatch;@DayZOrigins;@DayZ_Epoch;@DayZ_Epoch_Server;">Overpochins</option>
+  <param key="-noPause" type="select">
+    <option value="-mod=@DayZ;@Hive;">Vanilla</option>
+    <option value="-mod=@DayZ_Epoch;@DayZ_Epoch_Server;">Epoch</option>
+    <option value="-mod=@DayZOverwatch;@DayZ_Epoch;@DayZ_Epoch_Server;">Overpoch</option>
+    <option value="-mod=@DayZOrigins;@DayZ_Epoch;@DayZ_Epoch_Server;">Origins</option>
+    <option value="-mod=@DayZOverwatch;@DayZOrigins;@DayZ_Epoch;@DayZ_Epoch_Server;">Overpochins</option>
       <caption>DayZ Flavour</caption>
       <desc>Type of DayZ server you wish to run</desc>
-      <options>nsq</options>
     </param>
  </server_params>
 </game_config>

--- a/modules/config_games/server_configs/dayz_arma2oa_win32.xml
+++ b/modules/config_games/server_configs/dayz_arma2oa_win32.xml
@@ -4,11 +4,16 @@
  <lgsl_query_name>dayzmod</lgsl_query_name>
  <game_name>DayZ Mod (OA)</game_name>
  <server_exec_name>arma2oaserver.exe</server_exec_name>
- <cli_template>-autoInit -noSound -noPause "-mod=@DayZ_Epoch;@DayZ_Epoch_Server;" -name=epoch "-config=epoch\\server.cfg" "-cfg=epoch\\basic.cfg" -profiles=epoch %MEMORY%</cli_template>
+ <cli_template>%MEMORY% %PORT% %PLAYERS% "-config=profile\server.cfg" "-cfg=profile\basic.cfg" -profiles=profile -noSound -noPause</cli_template>
+ <cli_params>
+   <cli_param cli_string="-port=" id="PORT"/>
+   <cli_param id="PLAYERS" cli_string="-maxplayers=" />
+ </cli_params>
  <reserve_ports>
     <port type="add" id="QUERY_PORT">1</port>
  </reserve_ports>
- <console_log>epoch/arma2oaserver.RPT</console_log>
+ <cli_allow_chars>;</cli_allow_chars>
+ <console_log>profile/arma2oaserver.RPT</console_log>
  <max_user_amount>64</max_user_amount>
  <control_protocol>rcon2</control_protocol>
  <mods>
@@ -21,37 +26,37 @@
   <text key="home_name">
    <default>(hostName\s*=\s*")(.*)(";)</default>
    <var>hostName = "%key%";</var>
-   <filepath>epoch/server.cfg</filepath>
+   <filepath>profile/server.cfg</filepath>
    <options>key-regex</options>
   </text>
   <text key="max_players">
    <default>(maxPlayers\s*=\s*)(.*)(;)</default>
    <var>maxPlayers = %key%;</var>
-   <filepath>epoch/server.cfg</filepath>
+   <filepath>profile/server.cfg</filepath>
    <options>key-regex</options>
   </text>
   <text key="control_password">
    <default>(passwordAdmin\s*=\s*")(.*)(";)</default>
    <var>passwordAdmin = "%key%";</var>
-   <filepath>epoch/server.cfg</filepath>
+   <filepath>profile/server.cfg</filepath>
    <options>key-regex</options>
   </text>
   <text key="control_password">
    <default>(RConPassword\s*)(.*)</default>
    <var>RConPassword %key%</var>
-   <filepath>epoch/BattlEye/BEServer.cfg</filepath>
+   <filepath>profile/BattlEye/BEServer.cfg</filepath>
    <options>key-regex</options>
   </text>
   <text key="port">
    <default>(steamPort\s*=\s*)(.*)(;)</default>
    <var>steamPort = %key%;</var>
-   <filepath>epoch/server.cfg</filepath>
+   <filepath>profile/server.cfg</filepath>
    <options>key-regex</options>
   </text>
   <text key="query_port">
    <default>(steamQueryPort\s*=\s*)(.*)(;)</default>
    <var>steamQueryPort = %key%;</var>
-   <filepath>epoch/server.cfg</filepath>
+   <filepath>profile/server.cfg</filepath>
    <options>key-regex</options>
   </text>
  </replace_texts>
@@ -62,5 +67,15 @@
    <caption>Max RAM allocated</caption>
    <desc>Maximum usable memory in MB, for example: 1024</desc>
   </param>
+  <param key="-mod=" type="select">
+    <option value="@DayZ;@Hive;">Vanilla</option>
+    <option value="@DayZ_Epoch;@DayZ_Epoch_Server;">Epoch</option>
+    <option value="@DayZOverwatch;@DayZ_Epoch;@DayZ_Epoch_Server;">Overpoch</option>
+    <option value="@DayZOrigins;@DayZ_Epoch;@DayZ_Epoch_Server;">Origins</option>
+    <option value="@DayZOverwatch;@DayZOrigins;@DayZ_Epoch;@DayZ_Epoch_Server;">Overpochins</option>
+      <caption>DayZ Flavour</caption>
+      <desc>Type of DayZ server you wish to run</desc>
+      <options>nsq</options>
+    </param>
  </server_params>
 </game_config>


### PR DESCRIPTION
- Added the 5 most common DayZ flavours as a dropdown instead of having to edit the template for different DayZ server types
- Add port as 2 or more instances on the same machine without this parameter, instances after the first wont start.
- Fix config path as didnt work (Didnt need escaping)
- All Dayz instances use `profile` folder for config

Added template for Arma 3 (64-bit)