### PR TITLE
Remove rcon2 as control protocol for DayZ Mod

### DIFF
--- a/modules/config_games/cli-params.php
+++ b/modules/config_games/cli-params.php
@@ -168,6 +168,7 @@ function exec_ogp_module() {
 	   <option value="">None</option>
 	   <option value="rcon">HL/Quake/CoD Support</option>
 	   <option value="rcon2">HL2/Source Support</option>
+	   <option value="armabe">Arma 2 BattlEye Support</option>
 	  </select>
 	 </td>
 	</tr>

--- a/modules/config_games/schema_server_config.xml
+++ b/modules/config_games/schema_server_config.xml
@@ -63,6 +63,7 @@
       <xs:enumeration value="rcon" /><!-- HL, Q1/2/3 -->
       <xs:enumeration value="rcon2" /><!-- HL2(source) -->
       <xs:enumeration value="lcon" /><!-- legacy console -->
+      <xs:enumeration value="armabe" /><!-- Arma 2 BattlEye -->
       <xs:minLength value="1" />
     </xs:restriction>
   </xs:simpleType>

--- a/modules/config_games/server_configs/arma2_win32.xml
+++ b/modules/config_games/server_configs/arma2_win32.xml
@@ -11,7 +11,7 @@
   </cli_params>
 <console_log>profile/server_console.log</console_log>
 <max_user_amount>64</max_user_amount>
-<control_protocol>rcon2</control_protocol>
+<control_protocol>armabe</control_protocol>
 <mods>
  <mod key='arma2'>
   <name>none</name>

--- a/modules/config_games/server_configs/arma2co_win32.xml
+++ b/modules/config_games/server_configs/arma2co_win32.xml
@@ -11,7 +11,7 @@
   </cli_params>
 <console_log>profile/server_console.log</console_log>
 <max_user_amount>64</max_user_amount>
-<control_protocol>rcon2</control_protocol>
+<control_protocol>armabe</control_protocol>
 <mods>
  <mod key='arma2co'>
   <name>none</name>

--- a/modules/config_games/server_configs/arma2oa_win32.xml
+++ b/modules/config_games/server_configs/arma2oa_win32.xml
@@ -11,7 +11,7 @@
   </cli_params>
 <console_log>profile/server_console.log</console_log>
 <max_user_amount>64</max_user_amount>
-<control_protocol>rcon2</control_protocol>
+<control_protocol>armabe</control_protocol>
 <mods>
  <mod key='arma2oa'>
   <name>none</name>

--- a/modules/config_games/server_configs/dayz_arma2co_linux.xml
+++ b/modules/config_games/server_configs/dayz_arma2co_linux.xml
@@ -10,7 +10,7 @@
   <cli_param id="PORT" cli_string="-port=" />
  </cli_params>
  <console_log>cfgdayz/arma2oaserver.RPT</console_log>
- <control_protocol>rcon2</control_protocol>
+ <control_protocol>armabe</control_protocol>
  <mods>
   <mod key='dayzmod'>
    <name>none</name>

--- a/modules/config_games/server_configs/dayz_arma2co_win32.xml
+++ b/modules/config_games/server_configs/dayz_arma2co_win32.xml
@@ -9,7 +9,7 @@
   <cli_param id="PORT" cli_string="-port=" />
  </cli_params>
  <console_log>cfgdayz/arma2oaserver.RPT</console_log>
- <control_protocol>rcon2</control_protocol>
+ <control_protocol>armabe</control_protocol>
  <mods>
   <mod key='dayzmod'>
    <name>none</name>

--- a/modules/config_games/server_configs/dayz_arma2oa_win32.xml
+++ b/modules/config_games/server_configs/dayz_arma2oa_win32.xml
@@ -15,7 +15,6 @@
  <cli_allow_chars>;</cli_allow_chars>
  <console_log>profile/arma2oaserver.RPT</console_log>
  <max_user_amount>64</max_user_amount>
- <control_protocol>rcon2</control_protocol>
  <mods>
   <mod key='dayzmod'>
    <name>none</name>

--- a/modules/config_games/server_configs/dayz_arma2oa_win32.xml
+++ b/modules/config_games/server_configs/dayz_arma2oa_win32.xml
@@ -15,6 +15,7 @@
  <cli_allow_chars>;</cli_allow_chars>
  <console_log>profile/arma2oaserver.RPT</console_log>
  <max_user_amount>64</max_user_amount>
+ <control_protocol>armabe</control_protocol>
  <mods>
   <mod key='dayzmod'>
    <name>none</name>

--- a/modules/gamemanager/server_monitor.php
+++ b/modules/gamemanager/server_monitor.php
@@ -482,7 +482,7 @@ function exec_ogp_module() {
 
 			if( $isAdmin )
 			{
-				if ( ( $server_xml->control_protocol and preg_match("/^(rcon|lcon|rcon2)$/" ,$server_xml->control_protocol) ) OR 
+				if ( ( $server_xml->control_protocol and preg_match("/^(rcon|lcon|rcon2|armabe)$/" ,$server_xml->control_protocol) ) OR 
 					 ( $server_xml->gameq_query_name and $server_xml->gameq_query_name == 'minecraft' ) )
 				{
 					$manager .= "<a class='monitorbutton' href='home.php?m=gamemanager&amp;p=rcon_presets&amp;home_id=".$server_home['home_id']."&amp;mod_id=".$server_home['mod_id']."'>


### PR DESCRIPTION
Doesnt seem to work, prevents ogp_api from shutting down the server

rcon2 doesnt seem to be a protocol supported by A2 (I suspect Arma use their own RCON protocol)