### PR TITLE
Modified form table class to match the new OGP lang format

### DIFF
--- a/includes/form_table_class.php
+++ b/includes/form_table_class.php
@@ -124,7 +124,7 @@ class FormTable {
 			print_failure(get_lang_f('invalid_setting_type',$type));
 		}
 
-		if ( defined($name."_info") )
+		if ( defined("OGP_LANG_".$name."_info") )
 		{
 			echo "</td><td><div class='image-tip' id='".$this->i."' ><img src='images/icon_help_small.gif' ><span class='tip' id='".$this->i."' >".str_replace("'",'"',get_lang($name."_info"))."</span></div></td></tr>";
 			$this->i++;


### PR DESCRIPTION
This way when it creates table, and there is a matching string with "_info" at the end, it creates the help icons back like before on the settings page and many other Panel pages.