### PR TITLE
Hotfix for TeamSpeak 3 xml

### DIFF
--- a/modules/config_games/server_configs/teamspeak3_linux32.xml
+++ b/modules/config_games/server_configs/teamspeak3_linux32.xml
@@ -48,6 +48,6 @@
     </param>
   </server_params>
   <lock_files>
-    teamspeak3-server_linux_amd64/ts3server
+    teamspeak3-server_linux_x86/ts3server
   </lock_files>
 </game_config>


### PR DESCRIPTION
- Fixed wrong path for locking binary file for Linux 32-bit OS