### PR TITLE
Update spigotmc_linux.xml

### DIFF
--- a/modules/config_games/server_configs/spigotmc_linux.xml
+++ b/modules/config_games/server_configs/spigotmc_linux.xml
@@ -4,7 +4,7 @@
   <gameq_query_name>minecraft</gameq_query_name>
   <game_name>Spigot Server</game_name>
   <server_exec_name>spigot_run</server_exec_name>
-  <cli_template>-Xincgc %XMX% -jar spigot.jar nogui</cli_template>
+  <cli_template>-XX:+UseConcMarkSweepGC %XMX% -jar spigot.jar nogui</cli_template>
   <max_user_amount>32</max_user_amount>
   <!-- <control_protocol>lcon</control_protocol> Enables legacy console, the output will be shown in the log file-->
   <mods>

--- a/modules/config_games/server_configs/spigotmc_linux.xml
+++ b/modules/config_games/server_configs/spigotmc_linux.xml
@@ -92,7 +92,7 @@ while test $# -gt 0; do
 	esac
 	shift
 done
-# java -Xincgc -Xmx1024M -XX:MaxPermSize=128M -jar spigot.jar nogui
+# java -XX:+UseConcMarkSweepGC -Xmx1024M -XX:MaxPermSize=128M -jar spigot.jar nogui
 RUNCMD=&quot;java$ARGS&quot;
 BTURL=&quot;https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar&quot;
 BT=&quot;BuildTools.jar&quot;


### PR DESCRIPTION
-XX:+UseConcMarkSweepGC will replace the old -Xincgc .
-Xincgc will result in java printing out the error : Could not create the java virtual machine
This fix will work on openjdk-11-jdk and openjdk-8-jdk for Linux

Tested on Ubuntu 18.04/16.04 with both openjdk 11/8 .