### PR TITLE
Adding fake Steam AppID

### DIFF
--- a/modules/config_games/server_configs/fivem_linux32.xml
+++ b/modules/config_games/server_configs/fivem_linux32.xml
@@ -2,6 +2,7 @@
   <game_key>fivem_linux32</game_key>
   <protocol>lgsl</protocol>
   <lgsl_query_name>fivem</lgsl_query_name>
+  <installer>steamcmd</installer>
   <game_name>FiveM</game_name>
   <server_exec_name>run.sh</server_exec_name>
   <cli_template>+exec server.cfg</cli_template>
@@ -9,6 +10,8 @@
   <mods>
     <mod key="default">
       <name>None</name>
+      <installer_name>0</installer_name>
+      <installer_login>anonymous</installer_login>
     </mod>
   </mods>
   <replace_texts>

--- a/modules/config_games/server_configs/fivem_win32.xml
+++ b/modules/config_games/server_configs/fivem_win32.xml
@@ -2,6 +2,7 @@
   <game_key>fivem_win32</game_key>
   <protocol>lgsl</protocol>
   <lgsl_query_name>fivem</lgsl_query_name>
+  <installer>steamcmd</installer>
   <game_name>FiveM</game_name>
   <server_exec_name>run.cmd</server_exec_name>
   <cli_template>+exec server.cfg</cli_template>
@@ -10,6 +11,8 @@
   <mods>
     <mod key="default">
       <name>None</name>
+      <installer_name>0</installer_name>
+      <installer_login>anonymous</installer_login>
     </mod>
   </mods>
   <replace_texts>


### PR DESCRIPTION
This way user can click the INSTALL VIA STEAM button to trigger a fake SteamCMD update, to then trigger the post install script installing the real server files.
This solves the issue with people unable to install this game server (supposedly possible to trigger the post install script if game server install with the shop module or WHMCS module.. can't confirm, but classic OGP user has no installation option without these changes).