### PR TITLE
Fixed server info/controls not showing when expanding via address/owner column

### DIFF
--- a/modules/gamemanager/server_monitor.php
+++ b/modules/gamemanager/server_monitor.php
@@ -494,7 +494,7 @@ function exec_ogp_module() {
 			// Template
 			@$first = "<tr class='maintr$trclass'>";
 				$first .= "<td class='collapsible sortHandle' data-status='$status' data-pos='$pos'><span class='hidden'>$order</span>" . "<img src='" . check_theme_image("images/$status.png") . "' />" . "</td>";
-				$first .= "<td class='collapsible sortHandle'>" . "<span class='hidden'>$mod</span><img src='$icon_path' />" . "</td>";
+				$first .= "<td class='collapsible sortHandle' data-status='$status' data-pos='$pos'>" . "<span class='hidden'>$mod</span><img src='$icon_path' />" . "</td>";
 				$first .= "<td class='collapsible serverId hide sortHandle'>" . $server_home["home_id"] . "</td>";
 				$first .= "<td class='collapsible serverName ignoreSortable' data-status='$status' data-pos='$pos'><b>" . htmlentities($server_home['home_name']) . "</b>$mod_name</td>";
 				$first .= "<td class='collapsible serverIPAddress ignoreSortable' data-status='$status' data-pos='$pos'>" . $address . "</td>";

--- a/modules/gamemanager/server_monitor.php
+++ b/modules/gamemanager/server_monitor.php
@@ -497,8 +497,8 @@ function exec_ogp_module() {
 				$first .= "<td class='collapsible sortHandle'>" . "<span class='hidden'>$mod</span><img src='$icon_path' />" . "</td>";
 				$first .= "<td class='collapsible serverId hide sortHandle'>" . $server_home["home_id"] . "</td>";
 				$first .= "<td class='collapsible serverName ignoreSortable' data-status='$status' data-pos='$pos'><b>" . htmlentities($server_home['home_name']) . "</b>$mod_name</td>";
-				$first .= "<td class='collapsible serverIPAddress ignoreSortable'>" . $address . "</td>";
-				$first .= "<td class='owner collapsible serverOwner ignoreSortable'>" . $user['users_login'] . "</td>";
+				$first .= "<td class='collapsible serverIPAddress ignoreSortable' data-status='$status' data-pos='$pos'>" . $address . "</td>";
+				$first .= "<td class='owner collapsible serverOwner ignoreSortable' data-status='$status' data-pos='$pos'>" . $user['users_login'] . "</td>";
 				$first .= "<td style='width:328px;padding:0px;'>$ctrlChkBoxes</td>";
 			$first .= "</tr>";
 


### PR DESCRIPTION
I encountered an issue on Ubuntu 18.04 panel version d0c4f2b386cdc1e1172f899f56f5567eb02ff2ef (tested on Chrome, Firefox, and Internet Explorer) where the server's info and start/stop controls wouldn't show up when expanding the collapsible accordion by clicking on the address/owner columns (the info and controls would show up when clicking on the server name column). This change fixes that issue.