### PR TITLE
Fix error for Dashboard

### DIFF
--- a/protocol/lgsl/LGSLMonitor.php
+++ b/protocol/lgsl/LGSLMonitor.php
@@ -68,7 +68,8 @@ if($num_of_servers < $numberservers_to_skip_query)
 		$mapRaw = $data['s']['map'];
 		$address = $data['link'];
 		
-		if ( $data['s']['players'] > 0 )
+		if ( $data['s']['players'] > 0 && $_GET['m'] !== "dashboard" )
+
 			$player_list = print_player_list($data['p'],$players,$playersmax);
 			
 		$playersList = $data['p'];


### PR DESCRIPTION
After the fix for #481, I got error:
```
PHP Fatal error:  Uncaught Error: Call to undefined function print_player_list() in .../html/protocol/lgsl/LGSLMonitor.php:72
Stack trace:
#0 .../html/modules/dashboard/query_ref.php(76): require()
#1 .../html/includes/navig.php(106): exec_ogp_module()
#2 .../html/includes/navig.php(27): navigation()
#3 .../html/home.php(146): include('/home/vhosts/pa...')
#4 .../html/home.php(71): heading(true)
#5 {main}
  thrown in .../html/protocol/lgsl/LGSLMonitor.php on line 72
```
Looking at the code, I noticed it was still hitting the function `print_player_list()` inside of `protocol/lgsl/LGSLMonitor.php`, so I added a bypass if it comes in from the dashboard page. It now works again and pulls the server info.