### PR TITLE
Some changes for PHP 8 compatibility

### DIFF
--- a/includes/database_mysqli.php
+++ b/includes/database_mysqli.php
@@ -83,9 +83,6 @@ class OGPDatabaseMySQL extends OGPDatabase
 		if ( $result === FALSE )
 			return FALSE;
 
-		if ( mysqli_num_rows($result) == 0 )
-			return FALSE;
-
 		$results = array();
 
 		while ( $row = mysqli_fetch_assoc( $result ) )

--- a/index.php
+++ b/index.php
@@ -306,7 +306,7 @@ function ogpHome()
 					if( !$banlist_info )
 						$db->query("INSERT INTO `OGP_DB_PREFIXban_list` (`client_ip`) VALUES('$client_ip');");
 					
-					$db->logger( get_lang("bad_login") . " ( $login_attempts ) [ " . login . ": $_POST[ulogin], " . password . ": ******** ]" );
+					$db->logger( get_lang("bad_login") . " ( $login_attempts ) [ " . get_lang("login") . ": $_POST[ulogin], " . get_lang("password") . ": ******** ]" );
 					$db->query("UPDATE `OGP_DB_PREFIXban_list` SET logging_attempts='$login_attempts' WHERE client_ip='$client_ip';");
 					$view->refresh("index.php",2);
 				}

--- a/modules/config_games/config_servers.php
+++ b/modules/config_games/config_servers.php
@@ -173,8 +173,8 @@ function exec_ogp_module() {
 					foreach($value as $subkey => $subvalue )
 					{
 						echo "<tr><td><b>$subkey<b></td><td>$subvalue</td>\n";
-						
-						list($attributes,$attrvalue)=each($subvalue);
+
+						list($attributes,$attrvalue)=[key($subvalue), current($subvalue)];
 
 						foreach($attrvalue as $attrkey => $attrval)
 						{

--- a/modules/ftp/ftp_admin.php
+++ b/modules/ftp/ftp_admin.php
@@ -203,7 +203,7 @@ function exec_ogp_module()
 									{
 										$first_pos = array_shift($value_parts);
 										$parts = preg_split('/:|-/', $first_pos);
-										if(count(array_filter($parts, 'is_numeric') === 2))
+										if(array_filter($parts, 'is_numeric') === 2)
 										{
 											$value = $first_pos;
 											$advert = implode(" ", $value_parts);

--- a/modules/gamemanager/mini_start.php
+++ b/modules/gamemanager/mini_start.php
@@ -25,6 +25,14 @@
 $param_access_enabled = preg_match("/p/",$server_home['access_rights']) > 0 ? TRUE : FALSE;
 $extra_param_access_enabled = preg_match("/e/",$server_home['access_rights']) > 0 ? TRUE:FALSE;
 $last_param = json_decode($server_home['last_param'], True);
+if (is_null(json_decode($server_home['last_param'], True)))
+{
+	$last_param = array();
+}
+else
+{
+	$last_param = json_decode($server_home['last_param'], True);
+}
 
 $isAdmin = $db->isAdmin($_SESSION['user_id']);
 

--- a/modules/gamemanager/mini_start.php
+++ b/modules/gamemanager/mini_start.php
@@ -24,7 +24,6 @@
 
 $param_access_enabled = preg_match("/p/",$server_home['access_rights']) > 0 ? TRUE : FALSE;
 $extra_param_access_enabled = preg_match("/e/",$server_home['access_rights']) > 0 ? TRUE:FALSE;
-$last_param = json_decode($server_home['last_param'], True);
 if (is_null(json_decode($server_home['last_param'], True)))
 {
 	$last_param = array();

--- a/modules/gamemanager/monitor_buttons.php
+++ b/modules/gamemanager/monitor_buttons.php
@@ -77,7 +77,7 @@ if (preg_match("/u/",$server_home['access_rights']))
 		if ( in_array($sync_name, $sync_list) OR ($master_server_home_id != FALSE and $master_server_home_id != $server_home['home_id']) )
 		{
 			$module_buttons[] = "<a class='monitorbutton' href='?m=gamemanager&amp;p=rsync_install&amp;home_id=".$server_home['home_id']."&amp;mod_id=".$server_home['mod_id']."&amp;update=update'>
-				<img src='" . check_theme_image("images/rsync.png") . "' title='". rsync_install ."'>
+				<img src='" . check_theme_image("images/rsync.png") . "' title='". get_lang("rsync_install") ."'>
 				<span>". get_lang("rsync_install") ."</span>
 			</a>";
 		}

--- a/modules/update/blacklist.php
+++ b/modules/update/blacklist.php
@@ -90,7 +90,8 @@ function exec_ogp_module()
 		{
 			if(in_array($file,$current_blacklist))
 			{
-				if(!in_array($file,$_POST['blacklist']))
+                $blacklisted = isset( $_POST['blacklist'] ) ? $_POST['blacklist'] : array();
+				if(!in_array($file,$blacklisted)
 				{
 					$file = $db->real_escape_string($file);
 					$db->query("DELETE FROM `OGP_DB_PREFIXupdate_blacklist` WHERE file_path='$file';");

--- a/modules/update/update.php
+++ b/modules/update/update.php
@@ -170,7 +170,7 @@ function exec_ogp_module()
 								if ($commitsStart >= $commitsToShow) {
 									break;
 								}
-								echo '<li>'.substr($v['commit']['author']['date'],0,10).' - '.$v['commit']['author']['name'] .'</a> committed <a href="'.$v['html_url'].'" target="_blank">'.substr($v[sha],0,7).'...</a><br>';
+								echo '<li>'.substr($v['commit']['author']['date'],0,10).' - '.$v['commit']['author']['name'] .'</a> committed <a href="'.$v['html_url'].'" target="_blank">'.substr($v['sha'],0,7).'...</a><br>';
 								echo '<b>'.$v['commit']['message'] .'</b></li><br>';
 								++$commitsStart;
 							}

--- a/modules/user_games/custom_fields.php
+++ b/modules/user_games/custom_fields.php
@@ -105,7 +105,14 @@ function exec_ogp_module()
 		return;
 		
 	//get used custom value or get default
-	$custom_fields = json_decode($db->getCustomFields($home_id), True);
+	if (is_null(json_decode($db->getCustomFields($home_id), True)))
+	{
+		$custom_fields = array();
+	}
+	else
+	{
+		$custom_fields = json_decode($db->getCustomFields($home_id), True);
+	}
 		
 	$server_xml = read_server_config(SERVER_CONFIG_LOCATION.$home_info['home_cfg_file']);
 	

--- a/modules/user_games/edit_home.php
+++ b/modules/user_games/edit_home.php
@@ -885,7 +885,7 @@ function exec_ogp_module()
 						echo "<table class='center'><tr><td align='$align'>".$assigned_rows['ip'].":".$assigned_rows['port'].
 							 " <a href='?m=user_games&p=edit&home_id=$home_id&delete_ip&ip=".
 							 $assigned_rows['ip_id']."&port=".$assigned_rows['port'].
-							 "'>[ ". delete ." ]</a></td>\n".
+							 "'>[ ". get_lang("delete") ." ]</a></td>\n".
 							 $force_mod.
 							 "</tr>\n</table>\n";
 					}

--- a/modules/user_games/edit_home.php
+++ b/modules/user_games/edit_home.php
@@ -757,8 +757,8 @@ function exec_ogp_module()
 	if ( $isAdmin )
 	{
 		$master_server_home_id = $db->getMasterServer( $home_info['remote_server_id'], $home_info['home_cfg_id'] );
-		$expiration_date = !empty($home_info['server_expiration_date']) ? date( "d/m/Y H:i:s", $home_info['server_expiration_date'] ) : '';
-		
+		$expiration_date = $home_info['server_expiration_date'] != 'X' ? date( "d/m/Y H:i:s", $home_info['server_expiration_date'] ) : '';
+
 		if( $master_server_home_id != FALSE AND $master_server_home_id == $home_id )
 			$checked = 'checked ="checked"';
 		else


### PR DESCRIPTION
I've tried to fix some critical fatal errors after passing to PHP 8. I wanted to share my changes.

About this error, I preferred to remove the ```return FALSE``` for the ```function listQuery```, in this way every ```result``` will treated as array
```
[error] 13028#13028: *71795 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable|array, bool given in /var/www/example.com/modules/addonsmanager/monitor_buttons.php:36
Stack trace:
#0 /var/www/example.com/modules/gamemanager/home_handling_functions.php(461): require()
#1 /var/www/example.com/modules/gamemanager/server_monitor.php(402): get_monitor_buttons()
#2 /var/www/example.com/includes/navig.php(106): exec_ogp_module()
#3 /var/www/example.com/includes/navig.php(27): navigation()
#4 /var/www/example.com/home.php(146): include('...')
#5 /var/www/example.com/home.php(377): heading()
#6 /var/www/example.com/home.php(77): ogpHome()
  thrown in /var/www/example.com/modules/addonsmanager/monitor_buttons.php on line 36" while reading response header from upstream, client: 2001:b07:5d38:41eb:99a:ba9a:b72e:41f5, server: example.com, request: "GET /home.php?m=gamemanager&p=game_monitor&home_id-mod_id-ip-port=5--- HTTP/1.1", upstream: "fastcgi://unix:/var/run/php/php8.0-fpm_example.com.sock:", host: "example.com", referrer: "https://example.com/home.php?m=user_games"
```

This was just a developing oversight... just missing `get_lang("rsync_install")` in the `title=''` html tag
```
[error] 13034#13034: *72320 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Undefined constant "rsync_install" in /var/www/example.com/modules/gamemanager/monitor_buttons.php:80
Stack trace:
#0 /var/www/example.com/modules/gamemanager/home_handling_functions.php(461): require()
#1 /var/www/example.com/modules/gamemanager/server_monitor.php(402): get_monitor_buttons()
#2 /var/www/example.com/includes/navig.php(106): exec_ogp_module()
#3 /var/www/example.com/includes/navig.php(27): navigation()
#4 /var/www/example.com/home.php(146): include('...')
#5 /var/www/example.com/home.php(377): heading()
#6 /var/www/example.com/home.php(77): ogpHome()
#7 {main}
  thrown in /var/www/example.com/modules/gamemanager/monitor_buttons.php on line 80" while reading response header from upstream, client: 2001:b07:5d38:41eb:99a:ba9a:b72e:41f5, server: example.com, request: "GET /home.php?m=gamemanager&p=game_monitor&home_id-mod_id-ip-port=1-1-91.121.31.108-25565 HTTP/1.1", upstream: "fastcgi://unix:/var/run/php/php8.0-fpm_example.com.sock:", host: "example.com", referrer: "https://example.com/home.php?m=gamemanager&p=game_monitor&home_id-mod_id-ip-port=5---"
```

This error had me thinking... why you never used the `NULL` value for `server_expiration_date` (in database) instead of using a simple `X`. Anyway I made a small change, but now the `timestamp` in `date()`, as PHP 8 states, is nullable
```
[error] 13028#13028: *72342 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: date(): Argument #2 ($timestamp) must be of type ?int, string given in /var/www/example.com/modules/user_games/edit_home.php:760
Stack trace:
#0 /var/www/example.com/modules/user_games/edit_home.php(760): date()
#1 /var/www/example.com/includes/navig.php(106): exec_ogp_module()
#2 /var/www/example.com/includes/navig.php(27): navigation()
#3 /var/www/example.com/home.php(146): include('...')
#4 /var/www/example.com/home.php(377): heading()
#5 /var/www/example.com/home.php(77): ogpHome()
#6 {main}
  thrown in /var/www/example.com/modules/user_games/edit_home.php on line 760" while reading response header from upstream, client: 2001:b07:5d38:41eb:99a:ba9a:b72e:41f5, server: example.com, request: "GET /home.php?m=user_games&p=edit&home_id=5 HTTP/1.1", upstream: "fastcgi://unix:/var/run/php/php8.0-fpm_example.com.sock:", host: "example.com", referrer: "https://example.com/home.php?m=gamemanager&p=game_monitor&home_id-mod_id-ip-port=5---"
```

This was quite messy to understand... I still don't quite get still now why you used `count()` and identical comparison operation together which resolves only in a boolean result... counting boolean result is weird... I just removed it for the moment, if you intended something else, please explain.
```
[error] 13028#13028: *72601 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable|array, bool given in /var/www/example.com/modules/ftp/ftp_admin.php:207
Stack trace:
#0 /var/www/example.com/includes/navig.php(106): exec_ogp_module()
#1 /var/www/example.com/includes/navig.php(27): navigation()
#2 /var/www/example.com/home.php(146): include('...')
#3 /var/www/example.com/home.php(377): heading()
#4 /var/www/example.com/home.php(77): ogpHome()
#5 {main}
  thrown in /var/www/example.com/modules/ftp/ftp_admin.php on line 207" while reading response header from upstream, client: 2001:b07:5d38:41eb:99a:ba9a:b72e:41f5, server: example.com, request: "GET /home.php?m=ftp&p=ftp_admin HTTP/1.1", upstream: "fastcgi://unix:/var/run/php/php8.0-fpm_example.com.sock:", host: "example.com", referrer: "https://example.com/home.php?m=user_admin"
```

For the moment I only found this fatal errors... I will try to test it more to find others...