### PR TITLE
Secure admin e-mail address(es)

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -333,7 +333,16 @@ function mymail($email_address, $subject, $message, $panel_settings, $user_to_pa
 			$panel_email = $panel_settings['panel_email_address'];
 		}
 		
-		$email_addresses = explode( ",", $email_address );	
+		//$email_addresses = explode( ",", $email_address );
+		// Cheap way to parse Bcc addresses as defined in register-exec.php
+		$bcc_email_addresses = explode( "|", $email_address );
+		if (isset($bcc_email_addresses[1])) {
+			$email_addresses = explode( ",", $bcc_email_addresses[1] );
+			$bcc_email_addresses = explode( ",", $bcc_email_addresses[0] );
+		} else {
+			$bcc_email_addresses = 0;
+			$email_addresses = explode( ",", $email_address );
+		}
 				
 		if( $user_to_panel )
 		{
@@ -350,6 +359,15 @@ function mymail($email_address, $subject, $message, $panel_settings, $user_to_pa
 			foreach ( $email_addresses as $address ) 
 			{
 				$mail->AddAddress($address);
+			}
+			// Loop through Bcc addresses, if any, and add them as proper Bcc recipients
+			if ($bcc_email_addresses != 0) 
+			{
+    				foreach ( $bcc_email_addresses as $bcc_address ) 
+    				{
+					if ($bcc_address != "")
+        					$mail->addBCC($bcc_address);
+    				}
 			}
 			$mail->SetFrom($panel_email,$panel_name);
 			$mail->AddReplyTo($panel_email,$panel_name);

--- a/modules/register/register-exec.php
+++ b/modules/register/register-exec.php
@@ -179,7 +179,9 @@ function exec_ogp_module()
 			if($db->editUser($fields,$user_id))
 			{
 				if(isset($adminEmailList) && !empty($adminEmailList)){
-					$to = $adminEmailList . $users_email;
+					//$to = $adminEmailList . $users_email;
+					// Insert boundry char | to separate admins from users for Bcc recipient parsing in functions.php
+					$to = $adminEmailList . '|' . $users_email;
 				}else{
 					$to = $users_email;
 				}


### PR DESCRIPTION
Prevent disclosing admin e-mail address(es) when sending e-mails to users upon registration. This is a quick and dirty way to achieve the purpose, but doesn't cover any bases beyond registration. This should be implemented system-wide properly.