### PR TITLE
Update FiveM & RedM

### DIFF
--- a/modules/config_games/server_configs/fivem_linux32.xml
+++ b/modules/config_games/server_configs/fivem_linux32.xml
@@ -5,8 +5,8 @@
   <game_name>FiveM</game_name>
   <server_exec_name>run.sh</server_exec_name>
   <cli_template>+exec server.cfg</cli_template>
-  <max_user_amount>32</max_user_amount>
-   <control_protocol>rcon</control_protocol>
+  <max_user_amount>2048</max_user_amount>
+  <control_protocol>rcon</control_protocol>
   <control_protocol_type>old</control_protocol_type>
   <mods>
     <mod key="default">
@@ -46,81 +46,117 @@
     </text>
   </replace_texts>
   <custom_fields>
+    <field key="sets sv_projectName" type="text">
+      <default>sets sv_projectName.*</default>
+      <default_value>My FXServer Project</default_value>
+      <var>sets sv_projectName</var>
+      <filepath>server.cfg</filepath>
+      <options>sq</options>
+      <desc>Sets your servers Project Name</desc>
+    </field>
+    <field key="sets sv_projectDesc" type="text">
+      <default>sets sv_projectDesc.*</default>
+      <default_value>Default FXServer requiring configuration</default_value>
+      <var>sets sv_projectDesc</var>
+      <filepath>server.cfg</filepath>
+      <options>sq</options>
+      <desc>Sets your servers Project Description</desc>
+    </field>
     <field key="sv_licenseKey" type="text">
       <default>sv_licenseKey.*</default>
       <default_value></default_value>
       <var>sv_licenseKey</var>
       <filepath>server.cfg</filepath>
       <options>s</options>
-      <desc>Sets the license key. A license can be generated at: &lt;a href="https://keymaster.fivem.net/"&gt;https://keymaster.fivem.net/&lt;/a&gt;</desc>
+      <desc>Sets the License key. A License can be generated at: &lt;a href="https://keymaster.fivem.net/"&gt;https://keymaster.fivem.net/&lt;/a&gt;</desc>
     </field>
-	  <field key="set steam_webApiKey" type="text">
+    <field key="set steam_webApiKey" type="text">
       <default>set steam_webApiKey.*</default>
       <default_value></default_value>
       <var>set steam_webApiKey</var>
       <filepath>server.cfg</filepath>
       <options>sq</options>
       <desc>Steam Web API key, if you want to use Steam authentication: &lt;a href="https://steamcommunity.com/dev/apikey/"&gt;https://steamcommunity.com/dev/apikey/&lt;/a&gt;</desc>
-    </field>    
+    </field>
   </custom_fields>
   <post_install>
 cat > $PWD/server.cfg &lt;&lt;END
-# you probably don't want to change these!
-# only change them if you're using a server with multiple network interfaces
+# Only change the IP if you're using a server with multiple network interfaces, otherwise change the port only.
 endpoint_add_tcp "0.0.0.0:30120"
 endpoint_add_udp "0.0.0.0:30120"
 
+# These resources will start by default.
 ensure mapmanager
 ensure chat
 ensure spawnmanager
 ensure sessionmanager
-ensure fivem
+ensure basic-gamemode
 ensure hardcap
 ensure rconlog
-ensure scoreboard
-ensure playernames
 
-sv_scriptHookAllowed 1
+# This allows players to use scripthook-based plugins such as the legacy Lambda Menu.
+# Set this to 1 to allow scripthook. Do note that this does _not_ guarantee players won't be able to use external plugins.
+sv_scriptHookAllowed 0
 
-# change this
+# Uncomment this and set a password to enable RCON. Make sure to change the password - it should look like rcon_password "YOURPASSWORD"
 rcon_password ogpPassword
 
-sv_hostname "My new FXServer!"
+# A comma-separated list of tags for your server.
+# For example: sets tags "drifting, cars, racing"
+# Or: sets tags "roleplay, military, tanks"
+sets tags "default"
 
-# nested configs!
-# exec server_internal.cfg
+# A valid locale identifier for your server's primary language.
+# For example "en-US", "fr-CA", "nl-NL", "de-DE", "en-GB", "pt-BR"
+sets locale "en-US"
 
-# loading a server icon (96x96 PNG file)
+# Set an optional server info and connecting banner image url.
+# Size doesn't matter, any banner sized image will be fine.
+#sets banner_detail "https://url.to/image.png"
+#sets banner_connecting "https://url.to/image.png"
+
+# Set your server's hostname. This is not usually shown anywhere in listings.
+sv_hostname "FXServer, but unconfigured"
+
+# Set your server's Project Name
+sets sv_projectName "My FXServer Project"
+
+# Set your server's Project Description
+sets sv_projectDesc "Default FXServer requiring configuration"
+
+# Nested configs!
+#exec server_internal.cfg
+
+# Loading a server icon (96x96 PNG file)
 #load_server_icon myLogo.png
 
-# convars for use from script
-# set temp_convar "hey world!"
+# convars which can be used in scripts
+#set temp_convar "hey world!"
 
-# disable announcing? clear out the master by uncommenting this
+# Remove the `#` from the below line if you want your server to be listed as 'private' in the server browser.
+# Do not edit it if you *do not* want your server listed as 'private'.
+# Check the following url for more detailed information about this:
+# https://docs.fivem.net/docs/server-manual/server-commands/#sv_master1-newvalue
 #sv_master1 ""
 
-# want to only allow players authenticated with a third-party provider like Steam?
-#sv_authMaxVariance 1
-#sv_authMinTrust 5
+# Add system admins
+add_ace group.admin command allow # allow all commands
+add_ace group.admin command.quit deny # but don't allow quit
+add_principal identifier.fivem:1 group.admin # add the admin to the group
 
-# add system admins
-# add_ace group.admin command allow # allow all commands
-# add_ace group.admin command.quit deny # but don't allow quit
-# add_principal identifier.steam:110000112345678 group.admin # add the admin to the group
+# enable OneSync (required for server-side state awareness)
+set onesync on
 
-# remove the # to hide player endpoints in external log output
-#sv_endpointprivacy true
+# Server player slot limit (see https://fivem.net/server-hosting for limits)
+sv_maxclients 48
 
-# server slots limit (must be between 1 and 31)
-sv_maxclients 30
-
-# license key for server (https://keymaster.fivem.net)
-sv_licenseKey superduperkey
- 
 # Steam Web API key, if you want to use Steam authentication (https://steamcommunity.com/dev/apikey)
 # -> replace "" with the key
-set steam_webApiKey ""   
-    
+set steam_webApiKey ""
+
+# License key for your server (https://keymaster.fivem.net)
+sv_licenseKey superduperkey
+
 END
   </post_install>
   <configuration_files>

--- a/modules/config_games/server_configs/fivem_win32.xml
+++ b/modules/config_games/server_configs/fivem_win32.xml
@@ -6,7 +6,7 @@
   <server_exec_name>run.cmd</server_exec_name>
   <cli_template>+exec server.cfg</cli_template>
   <console_log>CitizenFX.log</console_log>
-  <max_user_amount>32</max_user_amount>
+  <max_user_amount>2048</max_user_amount>
   <control_protocol>rcon</control_protocol>
   <control_protocol_type>old</control_protocol_type>
   <mods>
@@ -47,13 +47,29 @@
     </text>
   </replace_texts>
   <custom_fields>
+    <field key="sets sv_projectName" type="text">
+      <default>sets sv_projectName.*</default>
+      <default_value>My FXServer Project</default_value>
+      <var>sets sv_projectName</var>
+      <filepath>server.cfg</filepath>
+      <options>sq</options>
+      <desc>Sets your servers Project Name</desc>
+    </field>
+    <field key="sets sv_projectDesc" type="text">
+      <default>sets sv_projectDesc.*</default>
+      <default_value>Default FXServer requiring configuration</default_value>
+      <var>sets sv_projectDesc</var>
+      <filepath>server.cfg</filepath>
+      <options>sq</options>
+      <desc>Sets your servers Project Description</desc>
+    </field>
     <field key="sv_licenseKey" type="text">
       <default>sv_licenseKey.*</default>
       <default_value></default_value>
       <var>sv_licenseKey</var>
       <filepath>server.cfg</filepath>
       <options>s</options>
-      <desc>Sets the license key. A license can be generated at: &lt;a href="https://keymaster.fivem.net/"&gt;https://keymaster.fivem.net/&lt;/a&gt;</desc>
+      <desc>Sets the License key. A License can be generated at: &lt;a href="https://keymaster.fivem.net/"&gt;https://keymaster.fivem.net/&lt;/a&gt;</desc>
     </field>
     <field key="set steam_webApiKey" type="text">
       <default>set steam_webApiKey.*</default>
@@ -62,66 +78,86 @@
       <filepath>server.cfg</filepath>
       <options>sq</options>
       <desc>Steam Web API key, if you want to use Steam authentication: &lt;a href="https://steamcommunity.com/dev/apikey/"&gt;https://steamcommunity.com/dev/apikey/&lt;/a&gt;</desc>
-    </field>    
+    </field>
   </custom_fields>
   <post_install>
 cat > $PWD/server.cfg &lt;&lt;END
-# you probably don't want to change these!
-# only change them if you're using a server with multiple network interfaces
+# Only change the IP if you're using a server with multiple network interfaces, otherwise change the port only.
 endpoint_add_tcp "0.0.0.0:30120"
 endpoint_add_udp "0.0.0.0:30120"
 
+# These resources will start by default.
 ensure mapmanager
 ensure chat
 ensure spawnmanager
 ensure sessionmanager
-ensure fivem
+ensure basic-gamemode
 ensure hardcap
 ensure rconlog
-ensure scoreboard
-ensure playernames
 
-sv_scriptHookAllowed 1
+# This allows players to use scripthook-based plugins such as the legacy Lambda Menu.
+# Set this to 1 to allow scripthook. Do note that this does _not_ guarantee players won't be able to use external plugins.
+sv_scriptHookAllowed 0
 
-# change this
+# Uncomment this and set a password to enable RCON. Make sure to change the password - it should look like rcon_password "YOURPASSWORD"
 rcon_password ogpPassword
 
-sv_hostname "My new FXServer!"
+# A comma-separated list of tags for your server.
+# For example: sets tags "drifting, cars, racing"
+# Or: sets tags "roleplay, military, tanks"
+sets tags "default"
 
-# nested configs!
-# exec server_internal.cfg
+# A valid locale identifier for your server's primary language.
+# For example "en-US", "fr-CA", "nl-NL", "de-DE", "en-GB", "pt-BR"
+sets locale "en-US"
 
-# loading a server icon (96x96 PNG file)
+# Set an optional server info and connecting banner image url.
+# Size doesn't matter, any banner sized image will be fine.
+#sets banner_detail "https://url.to/image.png"
+#sets banner_connecting "https://url.to/image.png"
+
+# Set your server's hostname. This is not usually shown anywhere in listings.
+sv_hostname "FXServer, but unconfigured"
+
+# Set your server's Project Name
+sets sv_projectName "My FXServer Project"
+
+# Set your server's Project Description
+sets sv_projectDesc "Default FXServer requiring configuration"
+
+# Nested configs!
+#exec server_internal.cfg
+
+# Loading a server icon (96x96 PNG file)
 #load_server_icon myLogo.png
 
-# convars for use from script
-# set temp_convar "hey world!"
+# convars which can be used in scripts
+#set temp_convar "hey world!"
 
-# disable announcing? clear out the master by uncommenting this
+# Remove the `#` from the below line if you want your server to be listed as 'private' in the server browser.
+# Do not edit it if you *do not* want your server listed as 'private'.
+# Check the following url for more detailed information about this:
+# https://docs.fivem.net/docs/server-manual/server-commands/#sv_master1-newvalue
 #sv_master1 ""
 
-# want to only allow players authenticated with a third-party provider like Steam?
-#sv_authMaxVariance 1
-#sv_authMinTrust 5
+# Add system admins
+add_ace group.admin command allow # allow all commands
+add_ace group.admin command.quit deny # but don't allow quit
+add_principal identifier.fivem:1 group.admin # add the admin to the group
 
-# add system admins
-# add_ace group.admin command allow # allow all commands
-# add_ace group.admin command.quit deny # but don't allow quit
-# add_principal identifier.steam:110000112345678 group.admin # add the admin to the group
+# enable OneSync (required for server-side state awareness)
+set onesync on
 
-# remove the # to hide player endpoints in external log output
-#sv_endpointprivacy true
+# Server player slot limit (see https://fivem.net/server-hosting for limits)
+sv_maxclients 48
 
-# server slots limit (must be between 1 and 31)
-sv_maxclients 30
-
-# license key for server (https://keymaster.fivem.net)
-sv_licenseKey superduperkey
-    
 # Steam Web API key, if you want to use Steam authentication (https://steamcommunity.com/dev/apikey)
 # -> replace "" with the key
 set steam_webApiKey ""
-    
+
+# License key for your server (https://keymaster.fivem.net)
+sv_licenseKey superduperkey
+
 END
   </post_install>
   <configuration_files>

--- a/modules/config_games/server_configs/redm_linux32.xml
+++ b/modules/config_games/server_configs/redm_linux32.xml
@@ -5,8 +5,8 @@
   <game_name>RedM</game_name>
   <server_exec_name>run.sh</server_exec_name>
   <cli_template>+set gamename rdr3 +exec server.cfg</cli_template>
-  <max_user_amount>32</max_user_amount>
-   <control_protocol>rcon</control_protocol>
+  <max_user_amount>1024</max_user_amount>
+  <control_protocol>rcon</control_protocol>
   <control_protocol_type>old</control_protocol_type>
   <mods>
     <mod key="default">
@@ -46,22 +46,38 @@
     </text>
   </replace_texts>
   <custom_fields>
+    <field key="sets sv_projectName" type="text">
+      <default>sets sv_projectName.*</default>
+      <default_value>My FXServer Project</default_value>
+      <var>sets sv_projectName</var>
+      <filepath>server.cfg</filepath>
+      <options>sq</options>
+      <desc>Sets your servers Project Name</desc>
+    </field>
+    <field key="sets sv_projectDesc" type="text">
+      <default>sets sv_projectDesc.*</default>
+      <default_value>Default FXServer requiring configuration</default_value>
+      <var>sets sv_projectDesc</var>
+      <filepath>server.cfg</filepath>
+      <options>sq</options>
+      <desc>Sets your servers Project Description</desc>
+    </field>
     <field key="sv_licenseKey" type="text">
       <default>sv_licenseKey.*</default>
       <default_value></default_value>
       <var>sv_licenseKey</var>
       <filepath>server.cfg</filepath>
       <options>s</options>
-      <desc>Sets the license key. A license can be generated at: &lt;a href="https://keymaster.fivem.net/"&gt;https://keymaster.fivem.net/&lt;/a&gt;</desc>
+      <desc>Sets the License key. A License can be generated at: &lt;a href="https://keymaster.fivem.net/"&gt;https://keymaster.fivem.net/&lt;/a&gt;</desc>
     </field>
-	 <field key="set steam_webApiKey" type="text">
+    <field key="set steam_webApiKey" type="text">
       <default>set steam_webApiKey.*</default>
       <default_value></default_value>
       <var>set steam_webApiKey</var>
       <filepath>server.cfg</filepath>
       <options>sq</options>
       <desc>Steam Web API key, if you want to use Steam authentication: &lt;a href="https://steamcommunity.com/dev/apikey/"&gt;https://steamcommunity.com/dev/apikey/&lt;/a&gt;</desc>
-    </field>    
+    </field>
   </custom_fields>
   <post_install>
 BASE="https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/"
@@ -79,58 +95,82 @@ unzip cfx-server-data.zip -d $PWD/server-data
 mv $PWD/server-data/cfx-server-data-master/resources $PWD/resources
 
 cat > $PWD/server.cfg &lt;&lt;END
-# you probably don't want to change these!
-# only change them if you're using a server with multiple network interfaces
+# Only change the IP if you're using a server with multiple network interfaces, otherwise change the port only.
 endpoint_add_tcp "0.0.0.0:30120"
 endpoint_add_udp "0.0.0.0:30120"
 
+# These resources will start by default.
 ensure mapmanager
 ensure chat
 ensure spawnmanager
-ensure rconlog
+ensure sessionmanager
 ensure basic-gamemode
+ensure hardcap
+ensure rconlog
 
-sv_scriptHookAllowed 1
+# This allows players to use scripthook-based plugins such as the legacy Lambda Menu.
+# Set this to 1 to allow scripthook. Do note that this does _not_ guarantee players won't be able to use external plugins.
+sv_scriptHookAllowed 0
 
-# change this
+# Uncomment this and set a password to enable RCON. Make sure to change the password - it should look like rcon_password "YOURPASSWORD"
 rcon_password ogpPassword
 
-sv_hostname "My new FXServer!"
+# A comma-separated list of tags for your server.
+# For example: sets tags "drifting, cars, racing"
+# Or: sets tags "roleplay, military, tanks"
+sets tags "default"
 
-# nested configs!
-# exec server_internal.cfg
+# A valid locale identifier for your server's primary language.
+# For example "en-US", "fr-CA", "nl-NL", "de-DE", "en-GB", "pt-BR"
+sets locale "en-US"
 
-# loading a server icon (96x96 PNG file)
+# Set an optional server info and connecting banner image url.
+# Size doesn't matter, any banner sized image will be fine.
+#sets banner_detail "https://url.to/image.png"
+#sets banner_connecting "https://url.to/image.png"
+
+# Set your server's hostname. This is not usually shown anywhere in listings.
+sv_hostname "FXServer, but unconfigured"
+
+# Set your server's Project Name
+sets sv_projectName "My FXServer Project"
+
+# Set your server's Project Description
+sets sv_projectDesc "Default FXServer requiring configuration"
+
+# Nested configs!
+#exec server_internal.cfg
+
+# Loading a server icon (96x96 PNG file)
 #load_server_icon myLogo.png
 
-# convars for use from script
-# set temp_convar "hey world!"
+# convars which can be used in scripts
+#set temp_convar "hey world!"
 
-# disable announcing? clear out the master by uncommenting this
+# Remove the `#` from the below line if you want your server to be listed as 'private' in the server browser.
+# Do not edit it if you *do not* want your server listed as 'private'.
+# Check the following url for more detailed information about this:
+# https://docs.fivem.net/docs/server-manual/server-commands/#sv_master1-newvalue
 #sv_master1 ""
 
-# want to only allow players authenticated with a third-party provider like Steam?
-#sv_authMaxVariance 1
-#sv_authMinTrust 5
+# Add system admins
+add_ace group.admin command allow # allow all commands
+add_ace group.admin command.quit deny # but don't allow quit
+add_principal identifier.fivem:1 group.admin # add the admin to the group
 
-# add system admins
-# add_ace group.admin command allow # allow all commands
-# add_ace group.admin command.quit deny # but don't allow quit
-# add_principal identifier.steam:110000112345678 group.admin # add the admin to the group
+# enable OneSync (required for server-side state awareness)
+set onesync on
 
-# remove the # to hide player endpoints in external log output
-#sv_endpointprivacy true
+# Server player slot limit (see https://fivem.net/server-hosting for limits)
+sv_maxclients 48
 
-# server slots limit (must be between 1 and 31)
-sv_maxclients 30
-
-# license key for server (https://keymaster.fivem.net)
-sv_licenseKey superduperkey
- 
 # Steam Web API key, if you want to use Steam authentication (https://steamcommunity.com/dev/apikey)
 # -> replace "" with the key
-set steam_webApiKey ""   
-    
+set steam_webApiKey ""
+
+# License key for your server (https://keymaster.fivem.net)
+sv_licenseKey superduperkey
+
 END
 
 rm tmp fx.tar.xz cfx-server-data.zip

--- a/modules/config_games/server_configs/redm_win32.xml
+++ b/modules/config_games/server_configs/redm_win32.xml
@@ -6,7 +6,7 @@
   <server_exec_name>run.cmd</server_exec_name>
   <cli_template>+set gamename rdr3 +exec server.cfg</cli_template>
   <console_log>CitizenFX.log</console_log>
-  <max_user_amount>32</max_user_amount>
+  <max_user_amount>1024</max_user_amount>
   <control_protocol>rcon</control_protocol>
   <control_protocol_type>old</control_protocol_type>
   <mods>
@@ -47,13 +47,29 @@
     </text>
   </replace_texts>
   <custom_fields>
+    <field key="sets sv_projectName" type="text">
+      <default>sets sv_projectName.*</default>
+      <default_value>My FXServer Project</default_value>
+      <var>sets sv_projectName</var>
+      <filepath>server.cfg</filepath>
+      <options>sq</options>
+      <desc>Sets your servers Project Name</desc>
+    </field>
+    <field key="sets sv_projectDesc" type="text">
+      <default>sets sv_projectDesc.*</default>
+      <default_value>Default FXServer requiring configuration</default_value>
+      <var>sets sv_projectDesc</var>
+      <filepath>server.cfg</filepath>
+      <options>sq</options>
+      <desc>Sets your servers Project Description</desc>
+    </field>
     <field key="sv_licenseKey" type="text">
       <default>sv_licenseKey.*</default>
       <default_value></default_value>
       <var>sv_licenseKey</var>
       <filepath>server.cfg</filepath>
       <options>s</options>
-      <desc>Sets the license key. A license can be generated at: &lt;a href="https://keymaster.fivem.net/"&gt;https://keymaster.fivem.net/&lt;/a&gt;</desc>
+      <desc>Sets the License key. A License can be generated at: &lt;a href="https://keymaster.fivem.net/"&gt;https://keymaster.fivem.net/&lt;/a&gt;</desc>
     </field>
     <field key="set steam_webApiKey" type="text">
       <default>set steam_webApiKey.*</default>
@@ -62,7 +78,7 @@
       <filepath>server.cfg</filepath>
       <options>sq</options>
       <desc>Steam Web API key, if you want to use Steam authentication: &lt;a href="https://steamcommunity.com/dev/apikey/"&gt;https://steamcommunity.com/dev/apikey/&lt;/a&gt;</desc>
-    </field>    
+    </field>
   </custom_fields>
   <post_install>
 BASE="https://runtime.fivem.net/artifacts/fivem/build_server_windows/master/"
@@ -80,66 +96,90 @@ unzip cfx-server-data.zip -d $PWD/server-data
 mv $PWD/server-data/cfx-server-data-master/resources $PWD/resources
 
 cat > $PWD/server.cfg &lt;&lt;END
-# you probably don't want to change these!
-# only change them if you're using a server with multiple network interfaces
+# Only change the IP if you're using a server with multiple network interfaces, otherwise change the port only.
 endpoint_add_tcp "0.0.0.0:30120"
 endpoint_add_udp "0.0.0.0:30120"
 
+# These resources will start by default.
 ensure mapmanager
 ensure chat
 ensure spawnmanager
-ensure rconlog
+ensure sessionmanager
 ensure basic-gamemode
+ensure hardcap
+ensure rconlog
 
-sv_scriptHookAllowed 1
+# This allows players to use scripthook-based plugins such as the legacy Lambda Menu.
+# Set this to 1 to allow scripthook. Do note that this does _not_ guarantee players won't be able to use external plugins.
+sv_scriptHookAllowed 0
 
-# change this
+# Uncomment this and set a password to enable RCON. Make sure to change the password - it should look like rcon_password "YOURPASSWORD"
 rcon_password ogpPassword
 
-sv_hostname "My new FXServer!"
+# A comma-separated list of tags for your server.
+# For example: sets tags "drifting, cars, racing"
+# Or: sets tags "roleplay, military, tanks"
+sets tags "default"
 
-# nested configs!
-# exec server_internal.cfg
+# A valid locale identifier for your server's primary language.
+# For example "en-US", "fr-CA", "nl-NL", "de-DE", "en-GB", "pt-BR"
+sets locale "en-US"
 
-# loading a server icon (96x96 PNG file)
+# Set an optional server info and connecting banner image url.
+# Size doesn't matter, any banner sized image will be fine.
+#sets banner_detail "https://url.to/image.png"
+#sets banner_connecting "https://url.to/image.png"
+
+# Set your server's hostname. This is not usually shown anywhere in listings.
+sv_hostname "FXServer, but unconfigured"
+
+# Set your server's Project Name
+sets sv_projectName "My FXServer Project"
+
+# Set your server's Project Description
+sets sv_projectDesc "Default FXServer requiring configuration"
+
+# Nested configs!
+#exec server_internal.cfg
+
+# Loading a server icon (96x96 PNG file)
 #load_server_icon myLogo.png
 
-# convars for use from script
-# set temp_convar "hey world!"
+# convars which can be used in scripts
+#set temp_convar "hey world!"
 
-# disable announcing? clear out the master by uncommenting this
+# Remove the `#` from the below line if you want your server to be listed as 'private' in the server browser.
+# Do not edit it if you *do not* want your server listed as 'private'.
+# Check the following url for more detailed information about this:
+# https://docs.fivem.net/docs/server-manual/server-commands/#sv_master1-newvalue
 #sv_master1 ""
 
-# want to only allow players authenticated with a third-party provider like Steam?
-#sv_authMaxVariance 1
-#sv_authMinTrust 5
+# Add system admins
+add_ace group.admin command allow # allow all commands
+add_ace group.admin command.quit deny # but don't allow quit
+add_principal identifier.fivem:1 group.admin # add the admin to the group
 
-# add system admins
-# add_ace group.admin command allow # allow all commands
-# add_ace group.admin command.quit deny # but don't allow quit
-# add_principal identifier.steam:110000112345678 group.admin # add the admin to the group
+# enable OneSync (required for server-side state awareness)
+set onesync on
 
-# remove the # to hide player endpoints in external log output
-#sv_endpointprivacy true
+# Server player slot limit (see https://fivem.net/server-hosting for limits)
+sv_maxclients 48
 
-# server slots limit (must be between 1 and 31)
-sv_maxclients 30
-
-# license key for server (https://keymaster.fivem.net)
-sv_licenseKey superduperkey
-    
 # Steam Web API key, if you want to use Steam authentication (https://steamcommunity.com/dev/apikey)
 # -> replace "" with the key
 set steam_webApiKey ""
-    
+
+# License key for your server (https://keymaster.fivem.net)
+sv_licenseKey superduperkey
+
 END
 
 rm tmp server.zip cfx-server-data.zip
 rm -rf $PWD/server-data
 echo "@echo off" > run.cmd
-echo "%~dp0\FXServer +set citizen_dir %~dp0\citizen\ %* > CitizenFX.log" >> run.cmd    
+echo "%~dp0\FXServer +set citizen_dir %~dp0\citizen\ %* > CitizenFX.log" >> run.cmd
   </post_install>
-  
+
   <configuration_files>
     <file description="Main Config File">server.cfg</file>
   </configuration_files>


### PR DESCRIPTION
- Update FiveM Max Slots to 2048
- Update RedM Max Slots to 1024
- Added Custom Field for sets sv_projectName
- Added Custom Field for sets sv_projectDesc
- Updated server.cfg to use FiveM's new server.cfg layout

The Max Slots for FiveM is 2048 & RedM is 1024 if you Subscribe to FiveM Patreon however default is set to 48 which is what FiveM now uses for servers that want the FREE OneSync. I also included their new Project Name & Project Desc into the Custom Fields to make it easier to Edit.