### PR TITLE
Set mysqli connection charset to utf8mb4

### DIFF
--- a/includes/database_mysqli.php
+++ b/includes/database_mysqli.php
@@ -64,6 +64,8 @@ class OGPDatabaseMySQL extends OGPDatabase
 		if ( $this->link === FALSE )
 			return -11;
 
+		mysqli_set_charset($this->link, "utf8mb4");
+
 		return TRUE;
 	}
 	


### PR DESCRIPTION
Without it, cyrillic letters(for example, in server name) are written to DB correctly, but when reading, transform to question marks.